### PR TITLE
add onDelete in riverpod provider

### DIFF
--- a/app/lib/providers/wallets_provider.dart
+++ b/app/lib/providers/wallets_provider.dart
@@ -17,6 +17,10 @@ class WalletsNotifier extends StateNotifier<List<Wallet>> {
     _loading = false;
   }
 
+  void removeWallet(String name) {
+    state = state.where((wallet) => wallet.name != name).toList();
+  }
+
   void reloadBalances() async {
     if (!_reload) return await TFChainService.disconnect();
     if (!_loading) {

--- a/app/lib/screens/wallets/wallet_screen.dart
+++ b/app/lib/screens/wallets/wallet_screen.dart
@@ -25,8 +25,7 @@ class _WalletScreenState extends ConsumerState<WalletScreen> {
   late WalletsNotifier walletRef;
 
   onDeleteWallet(String name) {
-    wallets = wallets.where((w) => w.name != name).toList();
-    setState(() {});
+    walletRef.removeWallet(name);
   }
 
   onEditWallet(String oldName, String newName) {


### PR DESCRIPTION
- Add `removeWallet` in wallets provider file, to make page reflect directly after deleting any wallet. 