### PR TITLE
Prevent saving old pin

### DIFF
--- a/app/lib/screens/change_pin_screen.dart
+++ b/app/lib/screens/change_pin_screen.dart
@@ -13,7 +13,7 @@ class ChangePinScreen extends StatefulWidget {
   State<ChangePinScreen> createState() => _ChangePinScreenState();
 }
 
-enum _State { newPinWrong, newPin, confirm, done }
+enum _State { newPinWrong, sameOldPin, newPin, confirm, done }
 
 class _ChangePinScreenState extends State<ChangePinScreen> {
   String newPin = '';
@@ -27,6 +27,8 @@ class _ChangePinScreenState extends State<ChangePinScreen> {
     switch (state) {
       case _State.newPinWrong:
         return 'Confirmation incorrect, please enter your new PIN';
+      case _State.sameOldPin:
+        return "New PIN can't match the old one";
       case _State.newPin:
         return 'Please enter your new PIN';
       case _State.confirm:
@@ -57,8 +59,18 @@ class _ChangePinScreenState extends State<ChangePinScreen> {
       switch (state) {
         case _State.newPinWrong:
         case _State.newPin:
-          newPin = enteredPinCode;
-          state = _State.confirm;
+          if (enteredPinCode == widget.currentPin) {
+            state = _State.sameOldPin;
+          } else {
+            newPin = enteredPinCode;
+            state = _State.confirm;
+          }
+          break;
+        case _State.sameOldPin:
+          if (enteredPinCode != widget.currentPin) {
+            newPin = enteredPinCode;
+            state = _State.confirm;
+          }
           break;
         case _State.confirm:
           if (newPin == enteredPinCode) {

--- a/app/lib/screens/change_pin_screen.dart
+++ b/app/lib/screens/change_pin_screen.dart
@@ -28,7 +28,7 @@ class _ChangePinScreenState extends State<ChangePinScreen> {
       case _State.newPinWrong:
         return 'Confirmation incorrect, please enter your new PIN';
       case _State.sameOldPin:
-        return "New PIN can't match the old one";
+        return "New PIN must not match the old one";
       case _State.newPin:
         return 'Please enter your new PIN';
       case _State.confirm:

--- a/app/lib/screens/recover_screen.dart
+++ b/app/lib/screens/recover_screen.dart
@@ -45,7 +45,8 @@ class _RecoverScreenState extends State<RecoverScreen> {
 
     Map<String, dynamic> body = json.decode(userInfoResult.body);
     if (body['publicKey'] != base64.encode(keyPair.publicKey)) {
-      throw Exception('Seed phrase does not match with ${doubleName.replaceAll('.3bot', '')}');
+      throw Exception(
+          'Seed phrase does not match with ${doubleName.replaceAll('.3bot', '')}');
     }
   }
 


### PR DESCRIPTION
### Changes

- Added a new state for which is used whenever the user tries to set new pin that matches the old one.

### Related issue: 

https://github.com/threefoldtech/threefold_connect/issues/630

### Tested Scenarios:

- write wrong old pin
- normal scenario
- set new pin same as old
- set new pin diff than old then the confirm w a diff pin