### PR TITLE
Validate name & seed in Recover form

### DIFF
--- a/app/lib/screens/preference_screen.dart
+++ b/app/lib/screens/preference_screen.dart
@@ -132,7 +132,8 @@ class _PreferenceScreenState extends ConsumerState<PreferenceScreen> {
                             }
                             biometricDeviceName = snapshot.data;
                             return CheckboxListTile(
-                              secondary: biometricDeviceName == 'Face ID'|| biometricDeviceName == 'Face unlock'
+                              secondary: biometricDeviceName == 'Face ID' ||
+                                      biometricDeviceName == 'Face unlock'
                                   ? Image.asset(
                                       'assets/face-id.png',
                                       color: Theme.of(context)

--- a/app/lib/screens/recover_screen.dart
+++ b/app/lib/screens/recover_screen.dart
@@ -86,6 +86,9 @@ class _RecoverScreenState extends State<RecoverScreen> {
 
   checkSeedLength(seedPhrase) {
     int seedLength = seedPhrase.split(' ').length;
+    if (seedLength == 1) {
+      throw ('Seed phrase is required.');
+    }
     if (seedLength <= 23) {
       throw ('Seed phrase is too short');
     } else if (seedLength > 24) {

--- a/app/lib/screens/recover_screen.dart
+++ b/app/lib/screens/recover_screen.dart
@@ -36,15 +36,26 @@ class _RecoverScreenState extends State<RecoverScreen> {
 
   validateNameSeed(doubleName, seedPhrase) async {
     try {
-      if (doubleName == '.3bot') {
-        throw ('Name is required.');
-      }
-
       Response userInfoResult = await getUserInfo(doubleName);
-      if (userInfoResult.statusCode != 200) {
-        throw ('Name was not found.');
-      }
+      await validateName(doubleName, userInfoResult);
+      await validateSeed(seedPhrase, userInfoResult);
+    } catch (e) {
+      rethrow;
+    }
+  }
 
+  validateName(String doubleName, userInfoResult) async {
+    if (doubleName == '.3bot') {
+      throw ('Name is required.');
+    }
+
+    if (userInfoResult.statusCode != 200) {
+      throw ('Name was not found.');
+    }
+  }
+
+  validateSeed(String seedPhrase, userInfoResult) async {
+    try {
       checkSeedLength(seedPhrase);
       KeyPair keyPair = await generateKeyPairFromSeedPhrase(seedPhrase);
       Map<String, dynamic> body = json.decode(userInfoResult.body);
@@ -55,7 +66,6 @@ class _RecoverScreenState extends State<RecoverScreen> {
       if (e.toString().contains('Invalid mnemonic')) {
         throw ('Invalid mnemonic');
       }
-      rethrow;
     }
   }
 

--- a/app/lib/screens/recover_screen.dart
+++ b/app/lib/screens/recover_screen.dart
@@ -33,19 +33,21 @@ class _RecoverScreenState extends State<RecoverScreen> {
 
   String errorStepperText = '';
 
-  checkSeedPhrase(doubleName, seedPhrase) async {
+  validateNameSeed(doubleName, seedPhrase) async {
     checkSeedLength(seedPhrase);
     KeyPair keyPair = await generateKeyPairFromSeedPhrase(seedPhrase);
-
     Response userInfoResult = await getUserInfo(doubleName);
+    Map<String, dynamic> body = json.decode(userInfoResult.body);
 
-    if (userInfoResult.statusCode != 200) {
-      throw Exception('Name was not found.');
+    if (doubleName == '.3bot') {
+      throw ('Name is required.');
     }
 
-    Map<String, dynamic> body = json.decode(userInfoResult.body);
+    if (userInfoResult.statusCode != 200) {
+      throw ('Name was not found.');
+    }
     if (body['publicKey'] != base64.encode(keyPair.publicKey)) {
-      throw Exception('Seed phrase does not match with ${doubleName.replaceAll('.3bot', '')}');
+      throw ('Seed phrase does not match with ${doubleName.replaceAll('.3bot', '')}');
     }
   }
 
@@ -78,16 +80,16 @@ class _RecoverScreenState extends State<RecoverScreen> {
       await fixPkidMigration();
     } catch (e) {
       print(e);
-      throw Exception('Something went wrong');
+      throw ('Something went wrong');
     }
   }
 
   checkSeedLength(seedPhrase) {
     int seedLength = seedPhrase.split(' ').length;
     if (seedLength <= 23) {
-      throw Exception('Seed phrase is too short');
+      throw ('Seed phrase is too short');
     } else if (seedLength > 24) {
-      throw Exception('Seed phrase is too long');
+      throw ('Seed phrase is too long');
     }
   }
 
@@ -223,7 +225,7 @@ class _RecoverScreenState extends State<RecoverScreen> {
                 try {
                   showSpinner();
 
-                  await checkSeedPhrase(doubleName, seedPhrase);
+                  await validateNameSeed(doubleName, seedPhrase);
                   await continueRecoverAccount();
 
                   // To dismiss the spinner

--- a/app/lib/screens/recover_screen.dart
+++ b/app/lib/screens/recover_screen.dart
@@ -34,20 +34,27 @@ class _RecoverScreenState extends State<RecoverScreen> {
   String errorStepperText = '';
 
   validateNameSeed(doubleName, seedPhrase) async {
-    checkSeedLength(seedPhrase);
-    KeyPair keyPair = await generateKeyPairFromSeedPhrase(seedPhrase);
-    Response userInfoResult = await getUserInfo(doubleName);
-    Map<String, dynamic> body = json.decode(userInfoResult.body);
+    try {
+      if (doubleName == '.3bot') {
+        throw ('Name is required.');
+      }
 
-    if (doubleName == '.3bot') {
-      throw ('Name is required.');
-    }
+      Response userInfoResult = await getUserInfo(doubleName);
+      if (userInfoResult.statusCode != 200) {
+        throw ('Name was not found.');
+      }
 
-    if (userInfoResult.statusCode != 200) {
-      throw ('Name was not found.');
-    }
-    if (body['publicKey'] != base64.encode(keyPair.publicKey)) {
-      throw ('Seed phrase does not match with ${doubleName.replaceAll('.3bot', '')}');
+      checkSeedLength(seedPhrase);
+      KeyPair keyPair = await generateKeyPairFromSeedPhrase(seedPhrase);
+      Map<String, dynamic> body = json.decode(userInfoResult.body);
+      if (body['publicKey'] != base64.encode(keyPair.publicKey)) {
+        throw ('Seed phrase does not match with ${doubleName.replaceAll('.3bot', '')}');
+      }
+    } catch (e) {
+      if (e.toString().contains('Invalid mnemonic')) {
+        throw ('Invalid mnemonic');
+      }
+      rethrow;
     }
   }
 


### PR DESCRIPTION
### Changes

- Add required name validation
- Refactor validateNameSeed
- Remove 'Exception'

### Related issues

- https://github.com/threefoldtech/threefold_connect/issues/575
- https://github.com/threefoldtech/threefold_connect/issues/542

### Tested Scenarios

- Recover w seed only
- Recover w name only
- Recover w wrong name
- Recover w wrong seed
- Recover w no inputs