### PR TITLE
Refactor wallet & farming screens

### DIFF
--- a/app/lib/providers/wallets_provider.dart
+++ b/app/lib/providers/wallets_provider.dart
@@ -14,16 +14,16 @@ class WalletsNotifier extends StateNotifier<List<Wallet>> {
 
   bool _reload = true;
   bool _loading = true;
-  bool _hasFetched = false;
+  bool _isListed = false;
   final Mutex _mutex = Mutex();
 
-  bool get hasFetched => _hasFetched;
+  bool get isListed => _isListed;
   Future<void> list() async {
-    if (_hasFetched) return;
+    if (_isListed) return;
     _loading = true;
     state = await listWallets();
     _loading = false;
-    _hasFetched = true;
+    _isListed = true;
   }
 
   Future<void> removeWallet(String name) async {

--- a/app/lib/providers/wallets_provider.dart
+++ b/app/lib/providers/wallets_provider.dart
@@ -8,16 +8,22 @@ import 'package:threebotlogin/services/stellar_service.dart' as StellarService;
 import 'package:threebotlogin/services/tfchain_service.dart' as TFChainService;
 
 class WalletsNotifier extends StateNotifier<List<Wallet>> {
-  WalletsNotifier() : super([]);
+  WalletsNotifier() : super([]) {
+    list();
+  }
 
   bool _reload = true;
   bool _loading = true;
+  bool _hasFetched = false;
   final Mutex _mutex = Mutex();
 
+  bool get hasFetched => _hasFetched;
   Future<void> list() async {
+    if (_hasFetched) return;
     _loading = true;
     state = await listWallets();
     _loading = false;
+    _hasFetched = true;
   }
 
   Future<void> removeWallet(String name) async {

--- a/app/lib/screens/farm_screen.dart
+++ b/app/lib/screens/farm_screen.dart
@@ -1,31 +1,44 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:threebotlogin/helpers/logger.dart';
 import 'package:threebotlogin/models/farm.dart';
 import 'package:threebotlogin/models/wallet.dart';
+import 'package:threebotlogin/providers/wallets_provider.dart';
 import 'package:threebotlogin/services/gridproxy_service.dart';
 import 'package:threebotlogin/services/tfchain_service.dart';
-import 'package:threebotlogin/services/wallet_service.dart';
 import 'package:threebotlogin/widgets/add_farm.dart';
 import 'package:threebotlogin/widgets/farm_item.dart';
 import 'package:threebotlogin/widgets/layout_drawer.dart';
 
-class FarmScreen extends StatefulWidget {
+class FarmScreen extends ConsumerStatefulWidget {
   const FarmScreen({super.key});
 
   @override
-  State<FarmScreen> createState() => _FarmScreenState();
+  ConsumerState<FarmScreen> createState() => _FarmScreenState();
 }
 
-class _FarmScreenState extends State<FarmScreen> {
+class _FarmScreenState extends ConsumerState<FarmScreen> {
   List<Farm> farms = [];
   List<Wallet> wallets = [];
-
   bool loading = true;
+  bool hasFetched = false;
 
   @override
   void initState() {
     super.initState();
-    listFarms();
+    _checkHasFetched();
+  }
+
+  Future<void> _checkHasFetched() async {
+    while (!hasFetched) {
+      await Future.delayed(const Duration(seconds: 3));
+      hasFetched =
+          ref.read(walletsNotifier.notifier.select((n) => n.hasFetched));
+      if (hasFetched) {
+        listFarms();
+        break;
+      }
+    }
   }
 
   Future<void> listFarms() async {
@@ -34,16 +47,20 @@ class _FarmScreenState extends State<FarmScreen> {
     });
     try {
       farms.clear();
-      wallets = await listWallets();
+      wallets = ref.read(walletsNotifier);
       final Map<int, Wallet> twinIdWallets = {};
-      for (final w in wallets) {
+
+      final twinIdFutures = wallets.map((w) async {
         final twinId = await getTwinId(w.tfchainSecret);
         if (twinId != 0) {
           twinIdWallets[twinId] = w;
         }
-      }
+      }).toList();
+
+      await Future.wait(twinIdFutures);
+
       final farmsList = await getFarmsByTwinIds(twinIdWallets.keys.toList());
-      for (final f in farmsList) {
+      final farmFutures = farmsList.map((f) async {
         final seed = twinIdWallets[f.twinId]!.tfchainSecret;
         final walletName = twinIdWallets[f.twinId]!.name;
         final nodes = await getNodesByFarmId(f.farmID);
@@ -61,7 +78,8 @@ class _FarmScreenState extends State<FarmScreen> {
                     e.toString().toLowerCase() == 'nodestatus.${n.status}'),
               );
             }).toList()));
-      }
+      }).toList();
+      await Future.wait(farmFutures);
     } catch (e) {
       logger.e('Failed to get farms due to $e');
       if (context.mounted) {

--- a/app/lib/screens/farm_screen.dart
+++ b/app/lib/screens/farm_screen.dart
@@ -21,21 +21,27 @@ class _FarmScreenState extends ConsumerState<FarmScreen> {
   List<Farm> farms = [];
   List<Wallet> wallets = [];
   bool loading = true;
-  bool hasFetched = false;
+  late bool isWalletListed;
 
   @override
   void initState() {
     super.initState();
-    _checkHasFetched();
+    isWalletListed =
+        ref.read(walletsNotifier.notifier.select((n) => n.hasFetched));
+    _listFarms();
   }
 
-  Future<void> _checkHasFetched() async {
-    while (!hasFetched) {
-      await Future.delayed(const Duration(seconds: 3));
-      hasFetched =
+  Future<void> _listFarms() async {
+    if (isWalletListed) {
+      await listFarms();
+      return;
+    }
+    while (!isWalletListed) {
+      await Future.delayed(const Duration(seconds: 5));
+      isWalletListed =
           ref.read(walletsNotifier.notifier.select((n) => n.hasFetched));
-      if (hasFetched) {
-        listFarms();
+      if (isWalletListed) {
+        await listFarms();
         break;
       }
     }

--- a/app/lib/screens/farm_screen.dart
+++ b/app/lib/screens/farm_screen.dart
@@ -21,26 +21,26 @@ class _FarmScreenState extends ConsumerState<FarmScreen> {
   List<Farm> farms = [];
   List<Wallet> wallets = [];
   bool loading = true;
-  late bool isWalletListed;
+  late bool areWalletsListed;
 
   @override
   void initState() {
     super.initState();
-    isWalletListed =
-        ref.read(walletsNotifier.notifier.select((n) => n.hasFetched));
+    areWalletsListed =
+        ref.read(walletsNotifier.notifier.select((n) => n.isListed));
     _listFarms();
   }
 
   Future<void> _listFarms() async {
-    if (isWalletListed) {
+    if (areWalletsListed) {
       await listFarms();
       return;
     }
-    while (!isWalletListed) {
+    while (!areWalletsListed) {
       await Future.delayed(const Duration(seconds: 5));
-      isWalletListed =
-          ref.read(walletsNotifier.notifier.select((n) => n.hasFetched));
-      if (isWalletListed) {
+      areWalletsListed =
+          ref.read(walletsNotifier.notifier.select((n) => n.isListed));
+      if (areWalletsListed) {
         await listFarms();
         break;
       }

--- a/app/lib/screens/home_screen.dart
+++ b/app/lib/screens/home_screen.dart
@@ -1,9 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-
-//import 'package:threebotlogin/apps/free_flow_pages/ffp.dart';
-//import 'package:threebotlogin/apps/free_flow_pages/ffp_events.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:threebotlogin/events/email_event.dart';
 import 'package:threebotlogin/events/go_news_event.dart';
 import 'package:threebotlogin/events/go_reservations_event.dart';
@@ -18,6 +16,7 @@ import 'package:threebotlogin/events/go_wallet_event.dart';
 import 'package:threebotlogin/events/new_login_event.dart';
 import 'package:threebotlogin/events/uni_link_event.dart';
 import 'package:threebotlogin/helpers/globals.dart';
+import 'package:threebotlogin/providers/wallets_provider.dart';
 import 'package:threebotlogin/screens/authentication_screen.dart';
 import 'package:threebotlogin/services/socket_service.dart';
 import 'package:threebotlogin/services/uni_link_service.dart';
@@ -230,6 +229,8 @@ class _HomeScreenState extends State<HomeScreen>
 
   @override
   Widget build(BuildContext context) {
+    ProviderScope.containerOf(context, listen: false)
+        .read(walletsNotifier.notifier);
     return Scaffold(
       resizeToAvoidBottomInset: false,
       appBar: PreferredSize(

--- a/app/lib/screens/wallets/wallet_screen.dart
+++ b/app/lib/screens/wallets/wallet_screen.dart
@@ -119,8 +119,8 @@ class _WalletScreenState extends ConsumerState<WalletScreen> {
     });
     try {
       await walletRef.list();
-      await Future.delayed(const Duration(milliseconds: 100));
-      if (wallets.isEmpty) {
+      await Future.delayed(const Duration(seconds: 1));
+      if (walletRef.isListed && wallets.isEmpty) {
         await _addInitialWallet();
       }
     } catch (e) {

--- a/app/lib/services/wallet_service.dart
+++ b/app/lib/services/wallet_service.dart
@@ -2,9 +2,11 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_pkid/flutter_pkid.dart';
+import 'package:gridproxy_client/models/farms.dart';
 import 'package:threebotlogin/apps/wallet/wallet_config.dart';
 import 'package:threebotlogin/helpers/globals.dart';
 import 'package:threebotlogin/models/wallet.dart';
+import 'package:threebotlogin/services/gridproxy_service.dart';
 import 'package:threebotlogin/services/pkid_service.dart';
 import 'package:threebotlogin/services/shared_preference_service.dart';
 import 'package:stellar_client/stellar_client.dart' as Stellar;
@@ -168,28 +170,21 @@ Future<Map<int, Map<String, String>>> getWalletTwinId(String walletName,
   return twinIdWallet;
 }
 
-Future<Map<int, Map<String, String>>> getWalletsTwinIds() async {
-  List<PkidWallet> pkidWallets = await getPkidWallets();
-  final String chainUrl = Globals().chainUrl;
-  final Map<int, Map<String, String>> twinWallets =
-      await compute((void _) async {
-    final List<Future<Map<int, Map<String, String>>>> twinIdWalletFutures = [];
-    final Map<int, Map<String, String>> twinWallets = {};
-    for (final w in pkidWallets) {
-      final twinIdWalletFuture =
-          getWalletTwinId(w.name, w.seed, w.type, chainUrl);
-      twinIdWalletFutures.add(twinIdWalletFuture);
-    }
+Future<List<Farm>> getDaoFarms(List<Wallet> wallets) async {
+  final Map<int, Wallet> twinIdWallets = {};
 
-    final twinWalletMaps = await Future.wait(twinIdWalletFutures);
-    for (var element in twinWalletMaps) {
-      twinWallets.addAll(element);
+  final twinIdFutures = wallets.map((w) async {
+    final twinId = await TFChainService.getTwinId(w.tfchainSecret);
+    if (twinId != 0) {
+      twinIdWallets[twinId] = w;
     }
-    return twinWallets;
-  }, null);
+  }).toList();
 
-  twinWallets.removeWhere((key, value) => key == 0);
-  return twinWallets;
+  await Future.wait(twinIdFutures);
+
+  final farms =
+      await getFarmsByTwinIds(twinIdWallets.keys.toList(), hasUpNode: true);
+  return farms;
 }
 
 Future<void> initializeWallet(String stellarSecret, String tfchainSeed) async {

--- a/app/lib/services/wallet_service.dart
+++ b/app/lib/services/wallet_service.dart
@@ -36,11 +36,8 @@ Future<List<PkidWallet>> getPkidWallets() async {
 
   Map<int, dynamic> dataMap = result.asMap();
   final pkidWallets =
-      dataMap.values.map((e) => PkidWallet.fromJson(e)).toList();
-  Set<String> walletsSet = {};
-  final filteredWallets =
-      pkidWallets.where((p) => walletsSet.add(p.seed)).toList();
-  return filteredWallets;
+      dataMap.values.map((e) => PkidWallet.fromJson(e)).toSet().toList();
+  return pkidWallets;
 }
 
 Future<List<Wallet>> listWallets() async {
@@ -122,11 +119,13 @@ Future<Wallet> loadWallet(String walletName, String walletSeed,
 Future<void> addWallet(String walletName, String walletSecret,
     {WalletType type = WalletType.IMPORTED}) async {
   List<PkidWallet> wallets = await getPkidWallets();
-  wallets.add(PkidWallet(
-      name: walletName,
-      index: type == WalletType.NATIVE ? 0 : -1,
-      seed: walletSecret,
-      type: type));
+  wallets.any((w) => w.seed == walletSecret)
+      ? throw Exception('Wallet already exists.')
+      : wallets.add(PkidWallet(
+          name: walletName,
+          index: type == WalletType.NATIVE ? 0 : -1,
+          seed: walletSecret,
+          type: type));
 
   await saveWalletsToPkid(wallets);
 }

--- a/app/lib/widgets/dao/vote_dialog.dart
+++ b/app/lib/widgets/dao/vote_dialog.dart
@@ -58,8 +58,11 @@ class _VoteDialogState extends ConsumerState<VoteDialog> {
 
   @override
   void initState() {
-    getFarms();
     super.initState();
+    Future.microtask(() async {
+      await ref.read(walletsNotifier.notifier).list();
+    });
+    getFarms();
   }
 
   List<DropdownMenuEntry<int>> _buildDropdownMenuEntries(List<Farm> farms) {

--- a/app/lib/widgets/dao/vote_dialog.dart
+++ b/app/lib/widgets/dao/vote_dialog.dart
@@ -1,13 +1,14 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gridproxy_client/models/farms.dart';
-
+import 'package:threebotlogin/providers/wallets_provider.dart';
+import 'package:threebotlogin/models/wallet.dart';
 import 'package:threebotlogin/services/tfchain_service.dart';
 import 'package:threebotlogin/services/gridproxy_service.dart';
-import 'package:threebotlogin/services/wallet_service.dart';
 import 'package:threebotlogin/widgets/custom_dialog.dart';
 
-class VoteDialog extends StatefulWidget {
+class VoteDialog extends ConsumerStatefulWidget {
   final String proposalHash;
   const VoteDialog({
     required this.proposalHash,
@@ -15,28 +16,43 @@ class VoteDialog extends StatefulWidget {
   });
 
   @override
-  State<VoteDialog> createState() => _VoteDialogState();
+  ConsumerState<VoteDialog> createState() => _VoteDialogState();
 }
 
-class _VoteDialogState extends State<VoteDialog> {
+class _VoteDialogState extends ConsumerState<VoteDialog> {
   int? farmId;
-  final List<Farm> farms = [];
+  List<Farm> farms = [];
   Map<int, Map<String, String>> twinIdWallets = {};
   bool loading = true;
   bool yesLoading = false;
   bool noLoading = false;
 
   void getFarms() async {
-    setState(() {
-      loading = true;
-    });
-    twinIdWallets = await getWalletsTwinIds();
-    List<Farm> farmsList =
-        await getFarmsByTwinIds(twinIdWallets.keys.toList(), hasUpNode: true);
-    farms.addAll(farmsList);
-    setState(() {
-      loading = false;
-    });
+    try {
+      setState(() {
+        loading = true;
+      });
+      farms.clear();
+      final wallets = ref.read(walletsNotifier);
+      final Map<int, Wallet> twinIdWallets = {};
+
+      final twinIdFutures = wallets.map((w) async {
+        final twinId = await getTwinId(w.tfchainSecret);
+        if (twinId != 0) {
+          twinIdWallets[twinId] = w;
+        }
+      }).toList();
+
+      await Future.wait(twinIdFutures);
+
+      farms = await getFarmsByTwinIds(twinIdWallets.keys.toList());
+    } catch (e) {
+      throw Exception('Failed to get farms due to $e');
+    } finally {
+      setState(() {
+        loading = false;
+      });
+    }
   }
 
   @override

--- a/app/lib/widgets/dao/vote_dialog.dart
+++ b/app/lib/widgets/dao/vote_dialog.dart
@@ -45,7 +45,8 @@ class _VoteDialogState extends ConsumerState<VoteDialog> {
 
       await Future.wait(twinIdFutures);
 
-      farms = await getFarmsByTwinIds(twinIdWallets.keys.toList());
+      farms =
+          await getFarmsByTwinIds(twinIdWallets.keys.toList(), hasUpNode: true);
     } catch (e) {
       throw Exception('Failed to get farms due to $e');
     } finally {

--- a/app/lib/widgets/dao/vote_dialog.dart
+++ b/app/lib/widgets/dao/vote_dialog.dart
@@ -3,9 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gridproxy_client/models/farms.dart';
 import 'package:threebotlogin/providers/wallets_provider.dart';
-import 'package:threebotlogin/models/wallet.dart';
 import 'package:threebotlogin/services/tfchain_service.dart';
-import 'package:threebotlogin/services/gridproxy_service.dart';
+import 'package:threebotlogin/services/wallet_service.dart';
 import 'package:threebotlogin/widgets/custom_dialog.dart';
 
 class VoteDialog extends ConsumerStatefulWidget {
@@ -32,21 +31,9 @@ class _VoteDialogState extends ConsumerState<VoteDialog> {
       setState(() {
         loading = true;
       });
-      farms.clear();
+      await ref.read(walletsNotifier.notifier).list();
       final wallets = ref.read(walletsNotifier);
-      final Map<int, Wallet> twinIdWallets = {};
-
-      final twinIdFutures = wallets.map((w) async {
-        final twinId = await getTwinId(w.tfchainSecret);
-        if (twinId != 0) {
-          twinIdWallets[twinId] = w;
-        }
-      }).toList();
-
-      await Future.wait(twinIdFutures);
-
-      farms =
-          await getFarmsByTwinIds(twinIdWallets.keys.toList(), hasUpNode: true);
+      farms = await getDaoFarms(wallets);
     } catch (e) {
       throw Exception('Failed to get farms due to $e');
     } finally {
@@ -59,9 +46,6 @@ class _VoteDialogState extends ConsumerState<VoteDialog> {
   @override
   void initState() {
     super.initState();
-    Future.microtask(() async {
-      await ref.read(walletsNotifier.notifier).list();
-    });
     getFarms();
   }
 


### PR DESCRIPTION
### Changes

- List wallets in the Wallet provider constructor
-  Add a flag to check if wallets have been listed before starting listing
- Exclude repeated wallets from PKID wallets,
- Wait for all futures at once
- List farms only if wallets are listed

### Related Issues

- https://github.com/threefoldtech/threefold_connect/issues/793
- https://github.com/threefoldtech/threefold_connect/issues/794
- https://github.com/threefoldtech/threefold_connect/issues/828
- https://github.com/threefoldtech/threefold_connect/issues/800


### Tested Scenarios

- Navigate to wallet then Farming
- Navigate to Farming then wallets
