### PR TITLE
Use wallet provider instead of fn propagation

### DIFF
--- a/app/lib/providers/wallets_provider.dart
+++ b/app/lib/providers/wallets_provider.dart
@@ -70,6 +70,10 @@ class WalletsNotifier extends StateNotifier<List<Wallet>> {
     _reload = true;
   }
 
+  void clear() {
+    _isListed = false;
+  }
+
   Wallet? getUpdatedWallet(String name) {
     return state.where((w) => w.name == name).firstOrNull;
   }

--- a/app/lib/providers/wallets_provider.dart
+++ b/app/lib/providers/wallets_provider.dart
@@ -32,6 +32,21 @@ class WalletsNotifier extends StateNotifier<List<Wallet>> {
     });
   }
 
+  Future<void> addWallet(Wallet wallet) async {
+    await _mutex.protect(() async {
+      state = [...state, wallet];
+    });
+  }
+
+  Future<void> editWallet(String oldName, String newName) async {
+    await _mutex.protect(() async {
+      final wallet = state.where((w) => w.name == oldName).firstOrNull;
+      if (wallet != null) {
+        wallet.name = newName;
+      }
+    });
+  }
+
   void reloadBalances() async {
     if (!_reload) return await TFChainService.disconnect();
     if (!_loading) {

--- a/app/lib/providers/wallets_provider.dart
+++ b/app/lib/providers/wallets_provider.dart
@@ -44,6 +44,7 @@ class WalletsNotifier extends StateNotifier<List<Wallet>> {
       if (wallet != null) {
         wallet.name = newName;
       }
+      state = [...state];
     });
   }
 

--- a/app/lib/screens/preference_screen.dart
+++ b/app/lib/screens/preference_screen.dart
@@ -13,6 +13,7 @@ import 'package:threebotlogin/events/events.dart';
 import 'package:threebotlogin/helpers/environment.dart';
 import 'package:threebotlogin/helpers/globals.dart';
 import 'package:threebotlogin/helpers/logger.dart';
+import 'package:threebotlogin/providers/wallets_provider.dart';
 
 import 'package:threebotlogin/screens/authentication_screen.dart';
 import 'package:threebotlogin/screens/change_pin_screen.dart';
@@ -324,6 +325,7 @@ class _PreferenceScreenState extends ConsumerState<PreferenceScreen> {
           bool result = false;
           if (deleted) {
             result = await clearData();
+            ref.read(walletsNotifier.notifier).clear();
             if (result) {
               Navigator.pop(context);
               await Navigator.pushReplacement(

--- a/app/lib/screens/wallets/bridge.dart
+++ b/app/lib/screens/wallets/bridge.dart
@@ -13,17 +13,15 @@ import 'package:validators/validators.dart';
 import 'package:threebotlogin/services/stellar_service.dart' as Stellar;
 import 'package:threebotlogin/services/tfchain_service.dart' as TFChain;
 
-class WalletBridgeScreen extends StatefulWidget {
-  const WalletBridgeScreen(
-      {super.key, required this.wallet, required this.allWallets});
+class WalletBridgeScreen extends ConsumerStatefulWidget {
+  const WalletBridgeScreen({super.key, required this.wallet});
   final Wallet wallet;
-  final List<Wallet> allWallets;
 
   @override
-  State<WalletBridgeScreen> createState() => _WalletBridgeScreenState();
+  ConsumerState<WalletBridgeScreen> createState() => _WalletBridgeScreenState();
 }
 
-class _WalletBridgeScreenState extends State<WalletBridgeScreen> {
+class _WalletBridgeScreenState extends ConsumerState<WalletBridgeScreen> {
   final fromController = TextEditingController();
   final toController = TextEditingController();
   final amountController = TextEditingController();
@@ -171,6 +169,7 @@ class _WalletBridgeScreenState extends State<WalletBridgeScreen> {
 
   @override
   Widget build(BuildContext context) {
+    List<Wallet> wallets = ref.read(walletsNotifier);
     final bool disableDeposit = widget.wallet.stellarBalance == '-1';
     if (disableDeposit && !isWithdraw) {
       onTransactionChange(BridgeOperation.Withdraw);
@@ -223,12 +222,12 @@ class _WalletBridgeScreenState extends State<WalletBridgeScreen> {
                                       : ChainType.TFChain,
                                   currentWalletAddress: fromController.text,
                                   wallets: isWithdraw
-                                      ? widget.allWallets
+                                      ? wallets
                                           .where((w) =>
                                               double.parse(w.stellarBalance) >=
                                               0)
                                           .toList()
-                                      : widget.allWallets,
+                                      : wallets,
                                   onSelectToAddress: _selectToAddress),
                             ));
                           },

--- a/app/lib/screens/wallets/send.dart
+++ b/app/lib/screens/wallets/send.dart
@@ -17,17 +17,15 @@ import 'package:validators/validators.dart';
 import 'package:threebotlogin/services/stellar_service.dart' as Stellar;
 import 'package:threebotlogin/services/tfchain_service.dart' as TFChain;
 
-class WalletSendScreen extends StatefulWidget {
-  const WalletSendScreen(
-      {super.key, required this.wallet, required this.allWallets});
+class WalletSendScreen extends ConsumerStatefulWidget {
+  const WalletSendScreen({super.key, required this.wallet});
   final Wallet wallet;
-  final List<Wallet> allWallets;
 
   @override
-  State<WalletSendScreen> createState() => _WalletSendScreenState();
+  ConsumerState<WalletSendScreen> createState() => _WalletSendScreenState();
 }
 
-class _WalletSendScreenState extends State<WalletSendScreen> {
+class _WalletSendScreenState extends ConsumerState<WalletSendScreen> {
   final fromController = TextEditingController();
   final toController = TextEditingController();
   final amountController = TextEditingController();
@@ -39,9 +37,12 @@ class _WalletSendScreenState extends State<WalletSendScreen> {
   bool reloadBalance = true;
   final FocusNode textFieldFocusNode = FocusNode();
   List percentages = [25, 50, 75, 100];
+  List<Wallet> wallets = [];
+
   @override
   void initState() {
     fromController.text = widget.wallet.stellarAddress;
+    wallets = ref.read(walletsNotifier);
     _reloadBalances();
     super.initState();
   }
@@ -127,8 +128,8 @@ class _WalletSendScreenState extends State<WalletSendScreen> {
         return false;
       }
 
-      final matchingWallets = widget.allWallets
-          .where((wallet) => wallet.stellarAddress == toAddress);
+      final matchingWallets =
+          wallets.where((wallet) => wallet.stellarAddress == toAddress);
       final Wallet? wallet =
           matchingWallets.isNotEmpty ? matchingWallets.first : null;
       if (wallet != null && wallet.stellarBalance == '-1') {
@@ -268,13 +269,13 @@ class _WalletSendScreenState extends State<WalletSendScreen> {
                                         currentWalletAddress:
                                             fromController.text,
                                         wallets: chainType == ChainType.Stellar
-                                            ? widget.allWallets
+                                            ? wallets
                                                 .where((w) =>
                                                     double.parse(
                                                         w.stellarBalance) >=
                                                     0)
                                                 .toList()
-                                            : widget.allWallets,
+                                            : wallets,
                                         onSelectToAddress: _selectToAddress),
                                   ));
                                 },

--- a/app/lib/screens/wallets/wallet_assets.dart
+++ b/app/lib/screens/wallets/wallet_assets.dart
@@ -13,10 +13,8 @@ import 'package:threebotlogin/widgets/wallets/arrow_inward.dart';
 import 'package:threebotlogin/widgets/wallets/balance_tile.dart';
 
 class WalletAssetsWidget extends StatefulWidget {
-  const WalletAssetsWidget(
-      {super.key, required this.wallet, required this.allWallets});
+  const WalletAssetsWidget({super.key, required this.wallet});
   final Wallet wallet;
-  final List<Wallet> allWallets;
 
   @override
   State<WalletAssetsWidget> createState() => _WalletAssetsWidgetState();
@@ -103,7 +101,6 @@ class _WalletAssetsWidgetState extends State<WalletAssetsWidget> {
                         Navigator.of(context).push(MaterialPageRoute(
                           builder: (context) => WalletSendScreen(
                             wallet: widget.wallet,
-                            allWallets: widget.allWallets,
                           ),
                         ));
                       },
@@ -163,7 +160,6 @@ class _WalletAssetsWidgetState extends State<WalletAssetsWidget> {
                         Navigator.of(context).push(MaterialPageRoute(
                           builder: (context) => WalletBridgeScreen(
                             wallet: widget.wallet,
-                            allWallets: widget.allWallets,
                           ),
                         ));
                       },

--- a/app/lib/screens/wallets/wallet_details.dart
+++ b/app/lib/screens/wallets/wallet_details.dart
@@ -5,16 +5,8 @@ import 'package:threebotlogin/screens/wallets/wallet_assets.dart';
 import 'package:threebotlogin/screens/wallets/wallet_info.dart';
 
 class WalletDetailsScreen extends StatefulWidget {
-  const WalletDetailsScreen(
-      {super.key,
-      required this.wallet,
-      required this.allWallets,
-      required this.onDeleteWallet,
-      required this.onEditWallet});
+  const WalletDetailsScreen({super.key, required this.wallet});
   final Wallet wallet;
-  final List<Wallet> allWallets;
-  final void Function(String name) onDeleteWallet;
-  final void Function(String oldName, String newName) onEditWallet;
 
   @override
   State<WalletDetailsScreen> createState() => _WalletDetailsScreenState();
@@ -29,12 +21,6 @@ class _WalletDetailsScreenState extends State<WalletDetailsScreen> {
     });
   }
 
-  void _onEditWallet(String oldName, String newName) {
-    widget.wallet.name = newName;
-    widget.onEditWallet(oldName, newName);
-    setState(() {});
-  }
-
   @override
   Widget build(BuildContext context) {
     Widget content;
@@ -45,12 +31,9 @@ class _WalletDetailsScreenState extends State<WalletDetailsScreen> {
     } else if (currentScreenIndex == 2) {
       content = WalletDetailsWidget(
         wallet: widget.wallet,
-        onDeleteWallet: widget.onDeleteWallet,
-        onEditWallet: _onEditWallet,
       );
     } else {
       content = WalletAssetsWidget(
-        allWallets: widget.allWallets,
         wallet: widget.wallet,
       );
     }

--- a/app/lib/screens/wallets/wallet_details.dart
+++ b/app/lib/screens/wallets/wallet_details.dart
@@ -1,18 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:threebotlogin/models/wallet.dart';
+import 'package:threebotlogin/providers/wallets_provider.dart';
 import 'package:threebotlogin/screens/wallets/transactions.dart';
 import 'package:threebotlogin/screens/wallets/wallet_assets.dart';
 import 'package:threebotlogin/screens/wallets/wallet_info.dart';
 
-class WalletDetailsScreen extends StatefulWidget {
+class WalletDetailsScreen extends ConsumerStatefulWidget {
   const WalletDetailsScreen({super.key, required this.wallet});
   final Wallet wallet;
 
   @override
-  State<WalletDetailsScreen> createState() => _WalletDetailsScreenState();
+  ConsumerState<WalletDetailsScreen> createState() =>
+      _WalletDetailsScreenState();
 }
 
-class _WalletDetailsScreenState extends State<WalletDetailsScreen> {
+class _WalletDetailsScreenState extends ConsumerState<WalletDetailsScreen> {
   int currentScreenIndex = 0;
 
   void _selectScreen(int index) {
@@ -24,6 +27,7 @@ class _WalletDetailsScreenState extends State<WalletDetailsScreen> {
   @override
   Widget build(BuildContext context) {
     Widget content;
+    ref.watch(walletsNotifier).firstWhere((w) => w.name == widget.wallet.name);
     if (currentScreenIndex == 1) {
       content = WalletTransactionsWidget(
         wallet: widget.wallet,

--- a/app/lib/screens/wallets/wallet_details.dart
+++ b/app/lib/screens/wallets/wallet_details.dart
@@ -21,10 +21,10 @@ class _WalletDetailsScreenState extends State<WalletDetailsScreen> {
     });
   }
 
-  void _onEditWallet(String oldName, String newName) {
-    widget.wallet.name = newName;
-    setState(() {});
-  }
+  // void _onEditWallet(String oldName, String newName) {
+  //   widget.wallet.name = newName;
+  //   setState(() {});
+  // }
 
   @override
   Widget build(BuildContext context) {
@@ -34,8 +34,7 @@ class _WalletDetailsScreenState extends State<WalletDetailsScreen> {
         wallet: widget.wallet,
       );
     } else if (currentScreenIndex == 2) {
-      content = WalletDetailsWidget(
-          wallet: widget.wallet, onEditWallet: _onEditWallet);
+      content = WalletDetailsWidget(wallet: widget.wallet);
     } else {
       content = WalletAssetsWidget(
         wallet: widget.wallet,

--- a/app/lib/screens/wallets/wallet_details.dart
+++ b/app/lib/screens/wallets/wallet_details.dart
@@ -21,6 +21,11 @@ class _WalletDetailsScreenState extends State<WalletDetailsScreen> {
     });
   }
 
+  void _onEditWallet(String oldName, String newName) {
+    widget.wallet.name = newName;
+    setState(() {});
+  }
+
   @override
   Widget build(BuildContext context) {
     Widget content;
@@ -30,8 +35,7 @@ class _WalletDetailsScreenState extends State<WalletDetailsScreen> {
       );
     } else if (currentScreenIndex == 2) {
       content = WalletDetailsWidget(
-        wallet: widget.wallet,
-      );
+          wallet: widget.wallet, onEditWallet: _onEditWallet);
     } else {
       content = WalletAssetsWidget(
         wallet: widget.wallet,

--- a/app/lib/screens/wallets/wallet_details.dart
+++ b/app/lib/screens/wallets/wallet_details.dart
@@ -21,11 +21,6 @@ class _WalletDetailsScreenState extends State<WalletDetailsScreen> {
     });
   }
 
-  // void _onEditWallet(String oldName, String newName) {
-  //   widget.wallet.name = newName;
-  //   setState(() {});
-  // }
-
   @override
   Widget build(BuildContext context) {
     Widget content;

--- a/app/lib/screens/wallets/wallet_info.dart
+++ b/app/lib/screens/wallets/wallet_info.dart
@@ -2,18 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:threebotlogin/helpers/logger.dart';
 import 'package:threebotlogin/models/wallet.dart';
+import 'package:threebotlogin/providers/wallets_provider.dart';
 import 'package:threebotlogin/services/wallet_service.dart';
 import 'package:threebotlogin/widgets/wallets/warning_dialog.dart';
 
 class WalletDetailsWidget extends StatefulWidget {
-  const WalletDetailsWidget(
-      {super.key,
-      required this.wallet,
-      required this.onDeleteWallet,
-      required this.onEditWallet});
+  const WalletDetailsWidget({
+    super.key,
+    required this.wallet,
+  });
   final Wallet wallet;
-  final void Function(String name) onDeleteWallet;
-  final void Function(String oldName, String newName) onEditWallet;
 
   @override
   State<WalletDetailsWidget> createState() => _WalletDetailsWidgetState();
@@ -30,11 +28,11 @@ class _WalletDetailsWidgetState extends State<WalletDetailsWidget> {
   bool showTfchainSecret = false;
   bool showStellarSecret = false;
   bool edit = false;
+  WalletsNotifier walletsNotifier = WalletsNotifier();
 
   Future<bool> _deleteWallet() async {
     try {
-      await deleteWallet(walletNameController.text);
-      widget.onDeleteWallet(walletNameController.text);
+      await walletsNotifier.removeWallet(walletNameController.text);
       return true;
     } catch (e) {
       logger.e('Failed to delete wallet due to $e');
@@ -68,7 +66,7 @@ class _WalletDetailsWidgetState extends State<WalletDetailsWidget> {
     }
     try {
       await editWallet(walletName, newName);
-      widget.onEditWallet(walletName, newName);
+      // widget.onEditWallet(walletName, newName);
       walletName = newName;
       widget.wallet.name = newName;
     } catch (e) {

--- a/app/lib/screens/wallets/wallet_info.dart
+++ b/app/lib/screens/wallets/wallet_info.dart
@@ -7,11 +7,10 @@ import 'package:threebotlogin/services/wallet_service.dart';
 import 'package:threebotlogin/widgets/wallets/warning_dialog.dart';
 
 class WalletDetailsWidget extends StatefulWidget {
-  const WalletDetailsWidget({
-    super.key,
-    required this.wallet,
-  });
+  const WalletDetailsWidget(
+      {super.key, required this.wallet, required this.onEditWallet});
   final Wallet wallet;
+  final void Function(String oldName, String newName) onEditWallet;
 
   @override
   State<WalletDetailsWidget> createState() => _WalletDetailsWidgetState();
@@ -66,7 +65,7 @@ class _WalletDetailsWidgetState extends State<WalletDetailsWidget> {
     }
     try {
       await editWallet(walletName, newName);
-      // widget.onEditWallet(walletName, newName);
+      widget.onEditWallet(walletName, newName);
       walletName = newName;
       widget.wallet.name = newName;
     } catch (e) {

--- a/app/lib/screens/wallets/wallet_info.dart
+++ b/app/lib/screens/wallets/wallet_info.dart
@@ -1,22 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:threebotlogin/helpers/logger.dart';
 import 'package:threebotlogin/models/wallet.dart';
 import 'package:threebotlogin/providers/wallets_provider.dart';
 import 'package:threebotlogin/services/wallet_service.dart';
 import 'package:threebotlogin/widgets/wallets/warning_dialog.dart';
 
-class WalletDetailsWidget extends StatefulWidget {
-  const WalletDetailsWidget(
-      {super.key, required this.wallet, required this.onEditWallet});
+class WalletDetailsWidget extends ConsumerStatefulWidget {
+  const WalletDetailsWidget({super.key, required this.wallet});
   final Wallet wallet;
-  final void Function(String oldName, String newName) onEditWallet;
 
   @override
-  State<WalletDetailsWidget> createState() => _WalletDetailsWidgetState();
+  ConsumerState<WalletDetailsWidget> createState() =>
+      _WalletDetailsWidgetState();
 }
 
-class _WalletDetailsWidgetState extends State<WalletDetailsWidget> {
+class _WalletDetailsWidgetState extends ConsumerState<WalletDetailsWidget> {
   final stellarSecretController = TextEditingController();
   final stellarAddressController = TextEditingController();
   final tfchainSecretController = TextEditingController();
@@ -27,11 +27,18 @@ class _WalletDetailsWidgetState extends State<WalletDetailsWidget> {
   bool showTfchainSecret = false;
   bool showStellarSecret = false;
   bool edit = false;
-  WalletsNotifier walletsNotifier = WalletsNotifier();
+  late WalletsNotifier walletsRef;
+
+  @override
+  void initState() {
+    super.initState();
+    walletsRef = ref.read(walletsNotifier.notifier);
+  }
 
   Future<bool> _deleteWallet() async {
     try {
-      await walletsNotifier.removeWallet(walletNameController.text);
+      await deleteWallet(walletNameController.text);
+      await walletsRef.removeWallet(walletNameController.text);
       return true;
     } catch (e) {
       logger.e('Failed to delete wallet due to $e');
@@ -65,9 +72,10 @@ class _WalletDetailsWidgetState extends State<WalletDetailsWidget> {
     }
     try {
       await editWallet(walletName, newName);
-      widget.onEditWallet(walletName, newName);
+      await walletsRef.editWallet(walletName, newName);
       walletName = newName;
       widget.wallet.name = newName;
+      setState(() {});
     } catch (e) {
       logger.e('Failed to modify wallet due to $e');
       if (context.mounted) {

--- a/app/lib/screens/wallets/wallet_info.dart
+++ b/app/lib/screens/wallets/wallet_info.dart
@@ -75,7 +75,6 @@ class _WalletDetailsWidgetState extends ConsumerState<WalletDetailsWidget> {
       await walletsRef.editWallet(walletName, newName);
       walletName = newName;
       widget.wallet.name = newName;
-      setState(() {});
     } catch (e) {
       logger.e('Failed to modify wallet due to $e');
       if (context.mounted) {

--- a/app/lib/screens/wallets/wallet_screen.dart
+++ b/app/lib/screens/wallets/wallet_screen.dart
@@ -25,19 +25,6 @@ class _WalletScreenState extends ConsumerState<WalletScreen> {
   List<Wallet> wallets = [];
   late WalletsNotifier walletRef;
 
-  onDeleteWallet(String name) {
-    walletRef.removeWallet(name);
-  }
-
-  onEditWallet(String oldName, String newName) {
-    for (final w in wallets) {
-      if (w.name == oldName) {
-        w.name = newName;
-      }
-    }
-    setState(() {});
-  }
-
   @override
   void initState() {
     super.initState();
@@ -91,9 +78,6 @@ class _WalletScreenState extends ConsumerState<WalletScreen> {
                 final wallet = wallets[i];
                 return WalletCardWidget(
                   wallet: wallet,
-                  allWallets: wallets,
-                  onDeleteWallet: onDeleteWallet,
-                  onEditWallet: onEditWallet,
                 );
               }));
     }
@@ -118,8 +102,7 @@ class _WalletScreenState extends ConsumerState<WalletScreen> {
       loading = true;
     });
     try {
-      await walletRef.list();
-      await Future.delayed(const Duration(milliseconds: 100));
+      wallets = ref.read(walletsNotifier);
       if (wallets.isEmpty) {
         await _addInitialWallet();
       }

--- a/app/lib/screens/wallets/wallet_screen.dart
+++ b/app/lib/screens/wallets/wallet_screen.dart
@@ -139,7 +139,6 @@ class _WalletScreenState extends ConsumerState<WalletScreen> {
         constraints: const BoxConstraints(maxWidth: double.infinity),
         context: context,
         builder: (ctx) => NewWallet(
-              onAddWallet: _addWallet,
               wallets: wallets,
             ));
   }
@@ -154,11 +153,6 @@ class _WalletScreenState extends ConsumerState<WalletScreen> {
         type: WalletType.NATIVE);
     await addWallet(walletName, walletSecret, type: WalletType.NATIVE);
     wallets.add(wallet);
-  }
-
-  void _addWallet(Wallet wallet) {
-    wallets.add(wallet);
-    setState(() {});
   }
 
   Future<void> handleRefresh() async {

--- a/app/lib/widgets/wallets/add_wallet.dart
+++ b/app/lib/widgets/wallets/add_wallet.dart
@@ -4,10 +4,12 @@ import 'package:bip39/bip39.dart';
 import 'package:convert/convert.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hashlib/hashlib.dart';
 import 'package:threebotlogin/helpers/globals.dart';
 import 'package:threebotlogin/helpers/logger.dart';
 import 'package:threebotlogin/models/wallet.dart';
+import 'package:threebotlogin/providers/wallets_provider.dart';
 import 'package:threebotlogin/services/stellar_service.dart';
 import 'package:threebotlogin/services/wallet_service.dart';
 import 'package:tfchain_client/src/utils.dart';
@@ -18,21 +20,20 @@ import 'package:stellar_client/stellar_client.dart' as Stellar;
 import 'package:bip39/bip39.dart';
 import 'package:substrate_bip39/substrate_bip39.dart';
 
-class NewWallet extends StatefulWidget {
-  const NewWallet(
-      {super.key, required this.onAddWallet, required this.wallets});
-  final void Function(Wallet addedWallet) onAddWallet;
+class NewWallet extends ConsumerStatefulWidget {
+  const NewWallet({super.key, required this.wallets});
   final List<Wallet> wallets;
 
   @override
-  State<StatefulWidget> createState() {
+  ConsumerState<ConsumerStatefulWidget> createState() {
     return _NewWalletState();
   }
 }
 
-class _NewWalletState extends State<NewWallet> {
+class _NewWalletState extends ConsumerState<NewWallet> {
   final _nameController = TextEditingController();
   final _secretController = TextEditingController();
+  late WalletsNotifier walletRef = ref.read(walletsNotifier.notifier);
   bool saveLoading = false;
   String? nameError;
   String? secretError;
@@ -190,6 +191,7 @@ class _NewWalletState extends State<NewWallet> {
     }
     try {
       await addWallet(walletName, walletSecret);
+      walletRef.addWallet(wallet);
       await _showDialog(
           'Wallet Added!',
           'Wallet $walletName has been added successfully',
@@ -203,7 +205,6 @@ class _NewWalletState extends State<NewWallet> {
       setState(() {});
       return;
     }
-    widget.onAddWallet(wallet);
     saveLoading = false;
     setState(() {});
     if (!context.mounted) return;

--- a/app/lib/widgets/wallets/wallet_card.dart
+++ b/app/lib/widgets/wallets/wallet_card.dart
@@ -1,32 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:threebotlogin/helpers/globals.dart';
 import 'package:threebotlogin/helpers/logger.dart';
 import 'package:threebotlogin/helpers/transaction_helpers.dart';
 import 'package:threebotlogin/models/wallet.dart';
+import 'package:threebotlogin/providers/wallets_provider.dart';
 import 'package:threebotlogin/screens/wallets/wallet_details.dart';
 import 'package:threebotlogin/services/stellar_service.dart' as StellarService;
 import 'package:threebotlogin/services/tfchain_service.dart' as TFChainService;
 import 'package:threebotlogin/services/wallet_service.dart';
 
-class WalletCardWidget extends StatefulWidget {
-  const WalletCardWidget(
-      {super.key,
-      required this.wallet,
-      required this.allWallets,
-      required this.onDeleteWallet,
-      required this.onEditWallet});
+class WalletCardWidget extends ConsumerStatefulWidget {
+  const WalletCardWidget({super.key, required this.wallet});
   final Wallet wallet;
-  final List<Wallet> allWallets;
-  final void Function(String name) onDeleteWallet;
-  final void Function(String oldName, String newName) onEditWallet;
 
   @override
-  State<WalletCardWidget> createState() => _WalletCardWidgetState();
+  ConsumerState<WalletCardWidget> createState() => _WalletCardWidgetState();
 }
 
-class _WalletCardWidgetState extends State<WalletCardWidget> {
+class _WalletCardWidgetState extends ConsumerState<WalletCardWidget> {
   bool initialWalletLoading = false;
-
+  List<Wallet> wallets = [];
   _initializeWallet() async {
     setState(() {
       initialWalletLoading = true;
@@ -67,6 +61,7 @@ class _WalletCardWidgetState extends State<WalletCardWidget> {
   @override
   Widget build(BuildContext context) {
     List<Widget> cardContent = [];
+    wallets = ref.read(walletsNotifier);
     if (widget.wallet.type == WalletType.NATIVE &&
         widget.wallet.stellarBalance == '-1') {
       cardContent = [
@@ -158,9 +153,6 @@ class _WalletCardWidgetState extends State<WalletCardWidget> {
           Navigator.of(context).push(MaterialPageRoute(
             builder: (context) => WalletDetailsScreen(
               wallet: widget.wallet,
-              allWallets: widget.allWallets,
-              onDeleteWallet: widget.onDeleteWallet,
-              onEditWallet: widget.onEditWallet,
             ),
           ));
         },

--- a/app/lib/widgets/wallets/wallet_card.dart
+++ b/app/lib/widgets/wallets/wallet_card.dart
@@ -61,7 +61,7 @@ class _WalletCardWidgetState extends ConsumerState<WalletCardWidget> {
   @override
   Widget build(BuildContext context) {
     List<Widget> cardContent = [];
-    wallets = ref.read(walletsNotifier);
+    wallets = ref.watch(walletsNotifier);
     if (widget.wallet.type == WalletType.NATIVE &&
         widget.wallet.stellarBalance == '-1') {
       cardContent = [


### PR DESCRIPTION
### Changes

- Remove props from all wallet screens
- Add clear function to wallets provider

### Related Issues

- https://github.com/threefoldtech/threefold_connect/issues/717

### Tested Scenarios

A list of scenarios tried to match the deliverables
