### PR TITLE
handle if editied wallet name exists before

### DIFF
--- a/app/lib/screens/wallets/wallet_details.dart
+++ b/app/lib/screens/wallets/wallet_details.dart
@@ -45,6 +45,7 @@ class _WalletDetailsScreenState extends State<WalletDetailsScreen> {
     } else if (currentScreenIndex == 2) {
       content = WalletDetailsWidget(
         wallet: widget.wallet,
+        wallets: widget.allWallets,
         onDeleteWallet: widget.onDeleteWallet,
         onEditWallet: _onEditWallet,
       );

--- a/app/lib/screens/wallets/wallet_info.dart
+++ b/app/lib/screens/wallets/wallet_info.dart
@@ -275,7 +275,7 @@ class _WalletDetailsWidgetState extends ConsumerState<WalletDetailsWidget> {
                 children: [
                   if (edit)
                     IconButton(
-                      onPressed: _editWallet,
+                      onPressed: _errorText == null ? _editWallet : null,
                       icon: const Icon(Icons.save),
                     ),
                   if (edit)

--- a/app/lib/screens/wallets/wallet_info.dart
+++ b/app/lib/screens/wallets/wallet_info.dart
@@ -36,7 +36,6 @@ class _WalletDetailsWidgetState extends ConsumerState<WalletDetailsWidget> {
     walletsRef = ref.read(walletsNotifier.notifier);
     walletNameController.text = widget.wallet.name;
     walletName = widget.wallet.name;
-    walletNameController.addListener(_validateWalletName);
   }
 
   Future<bool> _deleteWallet() async {
@@ -129,7 +128,6 @@ class _WalletDetailsWidgetState extends ConsumerState<WalletDetailsWidget> {
     stellarAddressController.dispose();
     tfchainSecretController.dispose();
     tfchainAddressController.dispose();
-    walletNameController.removeListener(_validateWalletName);
     walletNameController.dispose();
     super.dispose();
   }
@@ -269,6 +267,9 @@ class _WalletDetailsWidgetState extends ConsumerState<WalletDetailsWidget> {
                         color: Theme.of(context).colorScheme.onSurface,
                       ),
                   controller: walletNameController,
+                  onChanged: (text) {
+                    _validateWalletName();
+                  },
                   decoration: InputDecoration(
                     labelText: 'Wallet Name',
                     errorText: _errorText,

--- a/app/lib/screens/wallets/wallet_info.dart
+++ b/app/lib/screens/wallets/wallet_info.dart
@@ -9,9 +9,11 @@ class WalletDetailsWidget extends StatefulWidget {
   const WalletDetailsWidget(
       {super.key,
       required this.wallet,
+      required this.wallets,
       required this.onDeleteWallet,
       required this.onEditWallet});
   final Wallet wallet;
+  final List<Wallet> wallets;
   final void Function(String name) onDeleteWallet;
   final void Function(String oldName, String newName) onEditWallet;
 
@@ -65,6 +67,22 @@ class _WalletDetailsWidgetState extends State<WalletDetailsWidget> {
       FocusScope.of(context).requestFocus(nameFocus);
       setState(() {});
       return;
+    }
+    final w = widget.wallets.where((element) => element.name == walletName);
+    if (w.isNotEmpty) {
+      final editingWalletFailure = SnackBar(
+        content: Text(
+          'Name exists',
+          style: Theme.of(context)
+              .textTheme
+              .bodyMedium!
+              .copyWith(color: Theme.of(context).colorScheme.errorContainer),
+        ),
+        duration: const Duration(seconds: 3),
+      );
+      ScaffoldMessenger.of(context).clearSnackBars();
+      ScaffoldMessenger.of(context).showSnackBar(editingWalletFailure);
+      return false;
     }
     try {
       await editWallet(walletName, newName);
@@ -243,9 +261,26 @@ class _WalletDetailsWidgetState extends State<WalletDetailsWidget> {
                   decoration: const InputDecoration(
                     labelText: 'Wallet Name',
                   )),
-              trailing: IconButton(
-                  onPressed: _editWallet,
-                  icon: edit ? const Icon(Icons.save) : const Icon(Icons.edit)),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (edit)
+                    IconButton(
+                      onPressed: _editWallet,
+                      icon: const Icon(Icons.save),
+                    ),
+                  if (edit)
+                    IconButton(
+                      onPressed: _cancelEdit,
+                      icon: const Icon(Icons.cancel),
+                    ),
+                  if (!edit)
+                    IconButton(
+                      onPressed: _editWallet,
+                      icon: const Icon(Icons.edit),
+                    ),
+                ],
+              ),
             ),
             const SizedBox(height: 40),
             if (widget.wallet.type == WalletType.IMPORTED)
@@ -283,5 +318,12 @@ class _WalletDetailsWidgetState extends State<WalletDetailsWidget> {
         onAgree: _deleteWallet,
       ),
     );
+  }
+
+  void _cancelEdit() {
+    setState(() {
+      edit = false;
+      walletNameController.text = widget.wallet.name;
+    });
   }
 }

--- a/app/lib/screens/wallets/wallet_info.dart
+++ b/app/lib/screens/wallets/wallet_info.dart
@@ -33,6 +33,17 @@ class _WalletDetailsWidgetState extends State<WalletDetailsWidget> {
   bool showStellarSecret = false;
   bool edit = false;
 
+  @override
+  void initState() {
+    super.initState();
+    stellarSecretController.text = widget.wallet.stellarSecret;
+    stellarAddressController.text = widget.wallet.stellarAddress;
+    tfchainSecretController.text = widget.wallet.tfchainSecret;
+    tfchainAddressController.text = widget.wallet.tfchainAddress;
+    walletNameController.text = widget.wallet.name;
+    walletName = widget.wallet.name;
+  }
+
   Future<bool> _deleteWallet() async {
     try {
       await deleteWallet(walletNameController.text);
@@ -60,29 +71,34 @@ class _WalletDetailsWidgetState extends State<WalletDetailsWidget> {
     }
   }
 
+  String? get _errorText {
+    final text = walletNameController.value.text;
+    if (text.isEmpty) {
+      return 'Name can\'t be empty';
+    }
+    final duplicateWallet = widget.wallets
+        .where((element) => element.name == text && element != widget.wallet);
+    if (duplicateWallet.isNotEmpty) {
+      return 'Name exists';
+    }
+
+    return null;
+  }
+
   _editWallet() async {
-    edit = !edit;
-    final String newName = walletNameController.text.trim();
-    if (walletName == newName) {
+    setState(() {
+      edit = !edit;
+    });
+
+    if (edit) {
       FocusScope.of(context).requestFocus(nameFocus);
-      setState(() {});
       return;
     }
-    final w = widget.wallets.where((element) => element.name == walletName);
-    if (w.isNotEmpty) {
-      final editingWalletFailure = SnackBar(
-        content: Text(
-          'Name exists',
-          style: Theme.of(context)
-              .textTheme
-              .bodyMedium!
-              .copyWith(color: Theme.of(context).colorScheme.errorContainer),
-        ),
-        duration: const Duration(seconds: 3),
-      );
-      ScaffoldMessenger.of(context).clearSnackBars();
-      ScaffoldMessenger.of(context).showSnackBar(editingWalletFailure);
-      return false;
+
+    final String newName = walletNameController.text.trim();
+    if (walletName == newName) {
+      setState(() {});
+      return;
     }
     try {
       await editWallet(walletName, newName);
@@ -122,13 +138,6 @@ class _WalletDetailsWidgetState extends State<WalletDetailsWidget> {
 
   @override
   Widget build(BuildContext context) {
-    stellarSecretController.text = widget.wallet.stellarSecret;
-    stellarAddressController.text = widget.wallet.stellarAddress;
-    tfchainSecretController.text = widget.wallet.tfchainSecret;
-    tfchainAddressController.text = widget.wallet.tfchainAddress;
-    walletNameController.text = widget.wallet.name;
-    walletName = widget.wallet.name;
-
     return SingleChildScrollView(
       child: Padding(
         padding: const EdgeInsets.all(10),
@@ -258,8 +267,10 @@ class _WalletDetailsWidgetState extends State<WalletDetailsWidget> {
                         color: Theme.of(context).colorScheme.onSurface,
                       ),
                   controller: walletNameController,
-                  decoration: const InputDecoration(
+                  onChanged: (_) => setState(() {}),
+                  decoration: InputDecoration(
                     labelText: 'Wallet Name',
+                    errorText: _errorText,
                   )),
               trailing: Row(
                 mainAxisSize: MainAxisSize.min,

--- a/app/lib/screens/wallets/wallet_info.dart
+++ b/app/lib/screens/wallets/wallet_info.dart
@@ -28,17 +28,15 @@ class _WalletDetailsWidgetState extends ConsumerState<WalletDetailsWidget> {
   bool showStellarSecret = false;
   bool edit = false;
   late WalletsNotifier walletsRef;
+  String? _errorText;
 
   @override
   void initState() {
     super.initState();
-    stellarSecretController.text = widget.wallet.stellarSecret;
-    stellarAddressController.text = widget.wallet.stellarAddress;
-    tfchainSecretController.text = widget.wallet.tfchainSecret;
-    tfchainAddressController.text = widget.wallet.tfchainAddress;
+    walletsRef = ref.read(walletsNotifier.notifier);
     walletNameController.text = widget.wallet.name;
     walletName = widget.wallet.name;
-    walletsRef = ref.read(walletsNotifier.notifier);
+    walletNameController.addListener(_validateWalletName);
   }
 
   Future<bool> _deleteWallet() async {
@@ -68,33 +66,34 @@ class _WalletDetailsWidgetState extends ConsumerState<WalletDetailsWidget> {
     }
   }
 
-  String? get _errorText {
-    final text = walletNameController.value.text;
+  void _validateWalletName() {
+    final text = walletNameController.text.trim();
+    String? error;
+
     if (text.isEmpty) {
-      return 'Name can\'t be empty';
-    }
-    final wallets = ref.read(walletsNotifier);
-    final duplicateWallet = wallets
-        .where((element) => element.name == text && element != widget.wallet);
-    if (duplicateWallet.isNotEmpty) {
-      return 'Name exists';
+      error = 'Name can\'t be empty';
+    } else {
+      final wallets = ref.read(walletsNotifier);
+      final duplicateWallet = wallets.where(
+        (element) => element.name == text && element != widget.wallet,
+      );
+      if (duplicateWallet.isNotEmpty) {
+        error = 'Name exists';
+      }
     }
 
-    return null;
+    if (_errorText != error) {
+      setState(() {
+        _errorText = error;
+      });
+    }
   }
 
   _editWallet() async {
-    setState(() {
-      edit = !edit;
-    });
-
-    if (edit) {
-      FocusScope.of(context).requestFocus(nameFocus);
-      return;
-    }
-
+    edit = !edit;
     final String newName = walletNameController.text.trim();
     if (walletName == newName) {
+      FocusScope.of(context).requestFocus(nameFocus);
       setState(() {});
       return;
     }
@@ -130,12 +129,17 @@ class _WalletDetailsWidgetState extends ConsumerState<WalletDetailsWidget> {
     stellarAddressController.dispose();
     tfchainSecretController.dispose();
     tfchainAddressController.dispose();
+    walletNameController.removeListener(_validateWalletName);
     walletNameController.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    stellarSecretController.text = widget.wallet.stellarSecret;
+    stellarAddressController.text = widget.wallet.stellarAddress;
+    tfchainSecretController.text = widget.wallet.tfchainSecret;
+    tfchainAddressController.text = widget.wallet.tfchainAddress;
     return SingleChildScrollView(
       child: Padding(
         padding: const EdgeInsets.all(10),
@@ -265,7 +269,6 @@ class _WalletDetailsWidgetState extends ConsumerState<WalletDetailsWidget> {
                         color: Theme.of(context).colorScheme.onSurface,
                       ),
                   controller: walletNameController,
-                  onChanged: (_) => setState(() {}),
                   decoration: InputDecoration(
                     labelText: 'Wallet Name',
                     errorText: _errorText,

--- a/app/lib/screens/wallets/wallet_info.dart
+++ b/app/lib/screens/wallets/wallet_info.dart
@@ -337,6 +337,7 @@ class _WalletDetailsWidgetState extends ConsumerState<WalletDetailsWidget> {
     setState(() {
       edit = false;
       walletNameController.text = widget.wallet.name;
+      _errorText = null;
     });
   }
 }


### PR DESCRIPTION
### Changes

- Checked that wallet name won't be edited to existing name.
- Added cancel button for cancelling edit when there's an error.
### Related Issues

- https://github.com/threefoldtech/threefold_connect/issues/829
### Tested Scenarios
![image](https://github.com/user-attachments/assets/b254011e-0b48-41c5-850b-82239ae91304)

- If user tried to update wallet name to existing one, error will appear.