### PR TITLE
fix adding existing stellar secret

### DIFF
--- a/app/lib/widgets/wallets/add_wallet.dart
+++ b/app/lib/widgets/wallets/add_wallet.dart
@@ -138,6 +138,11 @@ class _NewWalletState extends State<NewWallet> {
       return false;
     }
 
+    if (walletSecret.startsWith('S') && widget.wallets.any((wallet) => wallet.stellarSecret == walletSecret)){
+      secretError = 'Secret already exists';
+      return false;
+    }
+
     if (isValidStellarSecret(walletSecret)) {
       return true;
     }

--- a/app/lib/widgets/wallets/add_wallet.dart
+++ b/app/lib/widgets/wallets/add_wallet.dart
@@ -151,6 +151,10 @@ class _NewWalletState extends State<NewWallet> {
       secretError = 'Invalid seed';
       return false;
     }
+    if (widget.wallets.any((wallet) => wallet.tfchainSecret == walletSecret)){
+      secretError = 'Secret already exists';
+      return false;      
+    }
     if (!walletSecret.startsWith('0x') && walletSecret.length != 64) {
       secretError = 'Invalid seed length';
       return false;


### PR DESCRIPTION
### Changes

- The stellar secret of 12 mnemonic wallet was added again without an error.
- Added a condition to check the provided stellar secret with existing ones
### Related Issues

- https://github.com/threefoldtech/threefold_connect/issues/830
### Tested Scenarios

- Tested with secret seed of 12 mnemonic account.
- Tested with secret seed of 24 mnemonic account.