### PR TITLE
Add error dialog from wrong QR Code

### DIFF
--- a/app/lib/screens/wallets/send.dart
+++ b/app/lib/screens/wallets/send.dart
@@ -385,6 +385,10 @@ class _WalletSendScreenState extends ConsumerState<WalletSendScreen> {
         _showInvalidQRCodeDialog();
         return;
       }
+      if (code.path == null) {
+        _showInvalidQRCodeDialog();
+        return;
+      }
       toController.text = code.path;
       if (code.queryParameters.containsKey('amount')) {
         amountController.text = code.queryParameters['amount']!;

--- a/app/lib/screens/wallets/send.dart
+++ b/app/lib/screens/wallets/send.dart
@@ -396,10 +396,7 @@ class _WalletSendScreenState extends ConsumerState<WalletSendScreen> {
       if (chainType == ChainType.Stellar &&
           code.queryParameters.containsKey('message')) {
         memoController.text = code.queryParameters['message']!;
-      } else {
-        _showInvalidQRCodeDialog();
-        return;
-      }
+      } 
       setState(() {});
     } else {
       _showInvalidQRCodeDialog();

--- a/app/lib/screens/wallets/send.dart
+++ b/app/lib/screens/wallets/send.dart
@@ -11,6 +11,7 @@ import 'package:threebotlogin/providers/wallets_provider.dart';
 import 'package:threebotlogin/screens/scan_screen.dart';
 import 'package:threebotlogin/screens/wallets/contacts.dart';
 import 'package:threebotlogin/services/stellar_service.dart';
+import 'package:threebotlogin/widgets/custom_dialog.dart';
 import 'package:threebotlogin/widgets/wallets/select_chain_widget.dart';
 import 'package:threebotlogin/widgets/wallets/send_confirmation.dart';
 import 'package:validators/validators.dart';
@@ -399,21 +400,21 @@ class _WalletSendScreenState extends ConsumerState<WalletSendScreen> {
   void _showInvalidQRCodeDialog() {
     showDialog(
       context: context,
-      builder: (BuildContext context) {
-        return AlertDialog(
-          title: const Text('Invalid QR Code'),
-          content: const Text(
-              'The QR code is missing required information or is invalid.'),
-          actions: <Widget>[
-            TextButton(
-              child: const Text('OK'),
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
-            ),
-          ],
-        );
-      },
+      builder: (BuildContext context) => CustomDialog(
+        type: DialogType.Warning,
+        image: Icons.warning,
+        title: 'Invalid QR Code',
+        description:
+            'The QR code is missing required information or is invalid.',
+        actions: [
+          TextButton(
+            child: const Text('Close'),
+            onPressed: () {
+              Navigator.pop(context);
+            },
+          ),
+        ],
+      ),
     );
   }
 

--- a/app/lib/screens/wallets/send.dart
+++ b/app/lib/screens/wallets/send.dart
@@ -376,8 +376,8 @@ class _WalletSendScreenState extends ConsumerState<WalletSendScreen> {
             MaterialPageRoute(builder: (context) => const ScanScreen()));
       }
     }
-    if (result.rawValue != null && result.rawValue!.startsWith('TFT')) {
-      late final code;
+    if (result.rawValue != null) {
+      late final Uri code;
       try {
         code = Uri.parse(result.rawValue!);
       } catch (e) {
@@ -385,7 +385,7 @@ class _WalletSendScreenState extends ConsumerState<WalletSendScreen> {
         _showInvalidQRCodeDialog();
         return;
       }
-      if (code.path == null) {
+      if (code.scheme != 'tft' || code.path.isEmpty) {
         _showInvalidQRCodeDialog();
         return;
       }

--- a/app/lib/screens/wallets/send.dart
+++ b/app/lib/screens/wallets/send.dart
@@ -5,6 +5,7 @@ import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:threebotlogin/helpers/globals.dart';
+import 'package:threebotlogin/helpers/logger.dart';
 import 'package:threebotlogin/helpers/transaction_helpers.dart';
 import 'package:threebotlogin/models/wallet.dart';
 import 'package:threebotlogin/providers/wallets_provider.dart';
@@ -375,8 +376,15 @@ class _WalletSendScreenState extends ConsumerState<WalletSendScreen> {
             MaterialPageRoute(builder: (context) => const ScanScreen()));
       }
     }
-    if (result.rawValue != null) {
-      final code = Uri.parse(result.rawValue!);
+    if (result.rawValue != null && result.rawValue!.startsWith('TFT')) {
+      late final code;
+      try {
+        code = Uri.parse(result.rawValue!);
+      } catch (e) {
+        logger.e('Error parsing QR Code, Error: $e');
+        _showInvalidQRCodeDialog();
+        return;
+      }
       toController.text = code.path;
       if (code.queryParameters.containsKey('amount')) {
         amountController.text = code.queryParameters['amount']!;

--- a/app/lib/screens/wallets/send.dart
+++ b/app/lib/screens/wallets/send.dart
@@ -414,7 +414,8 @@ class _WalletSendScreenState extends ConsumerState<WalletSendScreen> {
         image: Icons.warning,
         title: 'Invalid QR Code',
         description:
-            'The QR code is missing required information or is invalid.',
+            'The QR code is missing the required information or invalid.',
+
         actions: [
           TextButton(
             child: const Text('Close'),

--- a/app/lib/screens/wallets/send.dart
+++ b/app/lib/screens/wallets/send.dart
@@ -383,11 +383,38 @@ class _WalletSendScreenState extends ConsumerState<WalletSendScreen> {
       if (chainType == ChainType.Stellar &&
           code.queryParameters.containsKey('message')) {
         memoController.text = code.queryParameters['message']!;
+      } else {
+        _showInvalidQRCodeDialog();
+        return;
       }
       setState(() {});
+    } else {
+      _showInvalidQRCodeDialog();
+      return;
     }
 
     return result.rawValue!;
+  }
+
+  void _showInvalidQRCodeDialog() {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Invalid QR Code'),
+          content: const Text(
+              'The QR code is missing required information or is invalid.'),
+          actions: <Widget>[
+            TextButton(
+              child: const Text('OK'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
   }
 
   calculateAmount(int percentage) {


### PR DESCRIPTION
### Changes

- Added error dialog for invalid QR Code.
### Related Issues

- https://github.com/threefoldtech/threefold_connect/issues/850
### Tested Scenarios
![image](https://github.com/user-attachments/assets/3e49898b-25f4-4883-b1d8-2a815b285d18)

- Tried working qr code.
- Tried invalid qr code.