### PR TITLE
Revert KYC from farms

### DIFF
--- a/app/lib/apps/farmers/farmers.dart
+++ b/app/lib/apps/farmers/farmers.dart
@@ -27,7 +27,7 @@ class Farmers implements App {
 
   @override
   bool emailVerificationRequired() {
-    return false;
+    return true;
   }
 
   @override

--- a/app/lib/widgets/add_farm.dart
+++ b/app/lib/widgets/add_farm.dart
@@ -75,7 +75,6 @@ class _NewFarmState extends State<NewFarm> {
   _add(String farmName) async {
     Farm? farm;
     try {
-      //should be replace with email verification ??
         final f = await createFarm(farmName, _selectedWallet!.tfchainSecret,
             _selectedWallet!.stellarAddress);
         farm = Farm(

--- a/app/lib/widgets/add_farm.dart
+++ b/app/lib/widgets/add_farm.dart
@@ -1,12 +1,9 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:threebotlogin/helpers/globals.dart';
 import 'package:threebotlogin/helpers/logger.dart';
 import 'package:threebotlogin/models/farm.dart';
-import 'package:threebotlogin/models/idenfy.dart';
 import 'package:threebotlogin/models/wallet.dart';
 import 'package:threebotlogin/services/gridproxy_service.dart';
-import 'package:threebotlogin/services/idenfy_service.dart';
 import 'package:threebotlogin/services/tfchain_service.dart';
 import 'package:threebotlogin/widgets/custom_dialog.dart';
 

--- a/app/lib/widgets/add_farm.dart
+++ b/app/lib/widgets/add_farm.dart
@@ -75,10 +75,7 @@ class _NewFarmState extends State<NewFarm> {
   _add(String farmName) async {
     Farm? farm;
     try {
-      final idenfyServiceUrl = Globals().idenfyServiceUrl;
-      final kycVerified =
-          await getVerificationStatus(address: _selectedWallet!.tfchainAddress, idenfyServiceUrl: idenfyServiceUrl);
-      if (kycVerified.status == VerificationState.VERIFIED) {
+      //should be replace with email verification ??
         final f = await createFarm(farmName, _selectedWallet!.tfchainSecret,
             _selectedWallet!.stellarAddress);
         farm = Farm(
@@ -94,27 +91,6 @@ class _NewFarmState extends State<NewFarm> {
             'Farm $farmName has been added successfully',
             Icons.check,
             DialogType.Info);
-      } else {
-        saveLoading = false;
-        showDialog(
-            context: context,
-            builder: (BuildContext context) => CustomDialog(
-                  type: DialogType.Warning,
-                  image: Icons.warning,
-                  title: 'Unauthorized',
-                  description:
-                      'KYC verification is required for the selected wallet',
-                  actions: <Widget>[
-                    TextButton(
-                      child: const Text('Close'),
-                      onPressed: () {
-                        Navigator.pop(context);
-                      },
-                    ),
-                  ],
-                ));
-        return;
-      }
     } catch (e) {
       logger.e(e);
       _showDialog('Error', 'Failed to create farm. Please try again.',

--- a/app/lib/widgets/farm_item.dart
+++ b/app/lib/widgets/farm_item.dart
@@ -34,17 +34,12 @@ class _FarmItemWidgetState extends State<FarmItemWidget> {
   ChainType chainType = ChainType.Stellar;
   String? addressError;
   String? currentAddress;
-  String? tfchainAddress;
 
   @override
   void initState() {
     super.initState();
     currentAddress = widget.farm.walletAddress;
     walletAddressController.text = currentAddress!;
-    tfchainAddress = widget.wallets
-        .where((w) => w.name == widget.farm.walletName)
-        .first
-        .tfchainAddress;
   }
 
   @override
@@ -238,31 +233,31 @@ class _FarmItemWidgetState extends State<FarmItemWidget> {
                         children: [
                           IconButton(
                               onPressed: () async {
-                                final idenfyServiceUrl = Globals().idenfyServiceUrl;
-                                final kycVerified = await getVerificationStatus(
-                                    address: tfchainAddress!, idenfyServiceUrl: idenfyServiceUrl);
-                                if (kycVerified.status !=
-                                    VerificationState.VERIFIED) {
-                                  showDialog(
-                                      context: context,
-                                      builder: (BuildContext context) =>
-                                          CustomDialog(
-                                            type: DialogType.Warning,
-                                            image: Icons.warning,
-                                            title: 'Unauthorized',
-                                            description:
-                                                'KYC verification is required for the selected wallet',
-                                            actions: <Widget>[
-                                              TextButton(
-                                                child: const Text('Close'),
-                                                onPressed: () {
-                                                  Navigator.pop(context);
-                                                },
-                                              ),
-                                            ],
-                                          ));
-                                  return;
-                                }
+                                // final idenfyServiceUrl = Globals().idenfyServiceUrl;
+                                // final kycVerified = await getVerificationStatus(
+                                //     address: tfchainAddress!, idenfyServiceUrl: idenfyServiceUrl);
+                                // if (kycVerified.status !=
+                                //     VerificationState.VERIFIED) {
+                                //   showDialog(
+                                //       context: context,
+                                //       builder: (BuildContext context) =>
+                                //           CustomDialog(
+                                //             type: DialogType.Warning,
+                                //             image: Icons.warning,
+                                //             title: 'Unauthorized',
+                                //             description:
+                                //                 'KYC verification is required for the selected wallet',
+                                //             actions: <Widget>[
+                                //               TextButton(
+                                //                 child: const Text('Close'),
+                                //                 onPressed: () {
+                                //                   Navigator.pop(context);
+                                //                 },
+                                //               ),
+                                //             ],
+                                //           ));
+                                //   return;
+                                // }
                                 setState(() {
                                   edit = !edit;
                                 });

--- a/app/lib/widgets/farm_item.dart
+++ b/app/lib/widgets/farm_item.dart
@@ -1,15 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:threebotlogin/helpers/globals.dart';
 import 'package:threebotlogin/helpers/logger.dart';
 import 'package:threebotlogin/models/farm.dart';
-import 'package:threebotlogin/models/idenfy.dart';
 import 'package:threebotlogin/models/wallet.dart';
 import 'package:threebotlogin/screens/wallets/contacts.dart';
-import 'package:threebotlogin/services/idenfy_service.dart';
 import 'package:threebotlogin/services/stellar_service.dart';
 import 'package:threebotlogin/services/tfchain_service.dart';
-import 'package:threebotlogin/widgets/custom_dialog.dart';
 import 'package:threebotlogin/widgets/farm_node_item.dart';
 
 class FarmItemWidget extends StatefulWidget {

--- a/app/lib/widgets/farm_item.dart
+++ b/app/lib/widgets/farm_item.dart
@@ -228,7 +228,7 @@ class _FarmItemWidgetState extends State<FarmItemWidget> {
                         mainAxisAlignment: MainAxisAlignment.end,
                         children: [
                           IconButton(
-                              onPressed: () async {                              
+                              onPressed: () {                              
                                 setState(() {
                                   edit = !edit;
                                 });

--- a/app/lib/widgets/farm_item.dart
+++ b/app/lib/widgets/farm_item.dart
@@ -232,32 +232,7 @@ class _FarmItemWidgetState extends State<FarmItemWidget> {
                         mainAxisAlignment: MainAxisAlignment.end,
                         children: [
                           IconButton(
-                              onPressed: () async {
-                                // final idenfyServiceUrl = Globals().idenfyServiceUrl;
-                                // final kycVerified = await getVerificationStatus(
-                                //     address: tfchainAddress!, idenfyServiceUrl: idenfyServiceUrl);
-                                // if (kycVerified.status !=
-                                //     VerificationState.VERIFIED) {
-                                //   showDialog(
-                                //       context: context,
-                                //       builder: (BuildContext context) =>
-                                //           CustomDialog(
-                                //             type: DialogType.Warning,
-                                //             image: Icons.warning,
-                                //             title: 'Unauthorized',
-                                //             description:
-                                //                 'KYC verification is required for the selected wallet',
-                                //             actions: <Widget>[
-                                //               TextButton(
-                                //                 child: const Text('Close'),
-                                //                 onPressed: () {
-                                //                   Navigator.pop(context);
-                                //                 },
-                                //               ),
-                                //             ],
-                                //           ));
-                                //   return;
-                                // }
+                              onPressed: () async {                              
                                 setState(() {
                                   edit = !edit;
                                 });


### PR DESCRIPTION
### Changes

- Reverted changes of kyc required for farms.
- Updated farms screen to require only email verification.
### Related Issues

- https://github.com/threefoldtech/threefold_connect/issues/861
### Tested Scenarios

- Tried to open farms screen when email is not verified and a dialog appeared saying email should be verified.
<img src="https://github.com/user-attachments/assets/50a0ff81-fbb8-4254-90cb-228ffa7c81ac" width=250>
<img src="https://github.com/user-attachments/assets/108ad099-a81a-4463-ab6e-40112dc85569" width=250>

- Tried to open farms screen when email is verified and it opened.
- Tried to open farms screen when email is not verified and clicked `Resend email`, verified email and entered.
<img src="https://github.com/user-attachments/assets/afe7d76c-a0aa-4ac6-a646-ae174cb3fbce" width=250>
<img src="https://github.com/user-attachments/assets/e061adec-9b63-4724-88b0-2e89f5f6d19f" width=250>

