### PR TITLE
Update button renaming in phone widget

### DIFF
--- a/app/lib/screens/identity_verification_screen.dart
+++ b/app/lib/screens/identity_verification_screen.dart
@@ -503,8 +503,12 @@ class _IdentityVerificationScreenState
           }
 
           if (step == 2 && phoneCountdownNotifier.value == -1) {
-            await addPhoneNumberDialog(context,
-                newPhone: false, oldPhone: phone);
+            if (phone.isEmpty) {
+              await addPhoneNumberDialog(context, newPhone: true, oldPhone: '');
+            } else {
+              await addPhoneNumberDialog(context,
+                  newPhone: false, oldPhone: phone);
+            }
 
             var phoneMap = (await getPhone());
             if (phoneMap.isEmpty || !phoneMap.containsKey('phone')) {

--- a/app/lib/widgets/phone_widget.dart
+++ b/app/lib/widgets/phone_widget.dart
@@ -161,7 +161,9 @@ class PhoneAlertDialogState extends State<PhoneAlertDialog> {
                 Navigator.pop(context);
               }),
           if (valid)
-            TextButton(onPressed: verifyButton, child: const Text('Add'))
+            TextButton(
+                onPressed: verifyButton,
+                child: Text(widget.newPhone ? 'Add' : 'Update'))
         ]);
   }
 


### PR DESCRIPTION
### Changes

- Adding phone for the first time, the button will be `Add`.
- Editing the phone, the button will be `Update`.
- Fixed bug as it was shown `Update` in the first time of adding the phone. 
### Related Issues

- https://github.com/threefoldtech/threefold_connect/issues/879
### Tested Scenarios

<img src="https://github.com/user-attachments/assets/c447d000-8f25-4e2a-af9b-b8f95a6a8c14" width=250>
<img src="https://github.com/user-attachments/assets/453c51be-7ec4-4eee-9ce4-6a2f1cd127ed" width=250>

- Tested adding phone for the first time.
- Tested updating phone number.