### PR TITLE
fix button renaming when phone number is unkown

### DIFF
--- a/app/lib/screens/identity_verification_screen.dart
+++ b/app/lib/screens/identity_verification_screen.dart
@@ -669,7 +669,7 @@ class _IdentityVerificationScreenState
                                       await verifyPhone();
                                     }
                                   },
-                            child: const Text('Resend'),
+                            child: Text(phone.isEmpty ? 'Verify' : 'Resend'),
                           ),
                         );
                       },


### PR DESCRIPTION
### Changes

- Adde condition when phone number is empty the button will be `Verify`.
### Related Issues

- https://github.com/threefoldtech/threefold_connect/issues/910
### Tested Scenarios

- Tested with empty phone number.
- Tested with existing phone number.