### PR TITLE
Check pin exists before going to Home

### DIFF
--- a/app/lib/screens/main_screen.dart
+++ b/app/lib/screens/main_screen.dart
@@ -9,6 +9,7 @@ import 'package:threebotlogin/helpers/flags.dart';
 import 'package:threebotlogin/helpers/globals.dart';
 import 'package:threebotlogin/helpers/kyc_helpers.dart';
 import 'package:threebotlogin/helpers/logger.dart';
+import 'package:threebotlogin/screens/change_pin_screen.dart';
 import 'package:threebotlogin/screens/home_screen.dart';
 import 'package:threebotlogin/screens/init_screen.dart';
 import 'package:threebotlogin/screens/unregistered_screen.dart';
@@ -200,7 +201,16 @@ class _AppState extends State<MainScreen> {
       ScaffoldMessenger.of(context).showSnackBar(loadingTwinFailure);
       logger.e('Failed to load twin information due to $e');
     }
-
+    String? pin = await getPin();
+    if (pin == null) {
+      await Navigator.push(
+          context,
+          MaterialPageRoute(
+              builder: (context) => const ChangePinScreen(
+                    hideBackButton: true,
+                    currentPin: null,
+                  )));
+    }
     // await Navigator.push(context, MaterialPageRoute(builder: (context) => UnregisteredScreen()));
     await Navigator.of(context).pushReplacement(PageRouteBuilder(
         transitionDuration: const Duration(seconds: 1),


### PR DESCRIPTION
### Changes

- Added condition to check if pin exists before navigating to Home screen.
### Related Issues

- https://github.com/threefoldtech/threefold_connect/issues/903
### Tested Scenarios
- Created new account then didn't set a pin and closed the app. 
- Opened the app again and i was asked to set the ping before going to home screen.


https://github.com/user-attachments/assets/66e66d59-fc80-47de-8ebb-f8c1f8c449f8

https://github.com/user-attachments/assets/6eef5c9c-4a41-4d11-a48c-a35ebc6bff60

