### PR TITLE
Refactor identity page

### DIFF
--- a/app/lib/screens/identity_verification_screen.dart
+++ b/app/lib/screens/identity_verification_screen.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:core';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_pkid/flutter_pkid.dart';
 import 'package:threebotlogin/helpers/globals.dart';
 import 'package:threebotlogin/helpers/logger.dart';
 import 'package:threebotlogin/main.dart';
@@ -19,11 +21,14 @@ class IdentityVerificationScreen extends StatefulWidget {
 
   @override
   State<IdentityVerificationScreen> createState() =>
-      _IdentityVerificationScreenState();
+      IdentityVerificationScreenState();
 }
 
-class _IdentityVerificationScreenState
+class IdentityVerificationScreenState
     extends State<IdentityVerificationScreen> {
+    static final GlobalKey<IdentityVerificationScreenState> globalKey =
+      GlobalKey<IdentityVerificationScreenState>();
+
   final emailController = TextEditingController();
   final changeEmailController = TextEditingController();
   Globals globals = Globals();
@@ -159,6 +164,39 @@ class _IdentityVerificationScreenState
       Globals().hidePhoneButton.value = true;
     }
   }
+  verifyButton(bool valid, verificationPhoneNumber) async {
+    try {
+      if (!valid) return;
+      print('hereeeeee');
+      await loadingDialog();
+      print('after loading........');
+      await savePhone(verificationPhoneNumber, null);
+      FlutterPkid client = await getPkidClient();
+      client.setPKidDoc('phone', json.encode({'phone': verificationPhoneNumber}));
+      await sendPhoneVerification();
+      print('after verification');
+      // Navigator.pop(context);
+      getPhoneCountdown();
+      print('countdownnnnnnn');
+    } catch (e) {
+      logger.e(e);
+    }
+  }
+
+
+
+  sendPhoneVerification() async {
+    await sendVerificationSms();
+    Globals().hidePhoneButton.value = true;
+    Globals().smsSentOn = DateTime.now().millisecondsSinceEpoch;
+    if (mounted) {
+      setState(() {
+        phoneSendDialog(context);
+        Navigator.pop(context);
+        Navigator.pop(context);
+      });
+    }
+  }
 
   void getUserValues() async {
     doubleName = (await getDoubleName())?.replaceAll('.3bot', '') ?? 'Unknown';
@@ -220,11 +258,12 @@ class _IdentityVerificationScreenState
     }
   }
 
-  Future _loadingDialog() {
+  Future loadingDialog() {
+    print('loadingggggggggggggg');
     return showDialog(
       barrierDismissible: false,
       context: context,
-      builder: (BuildContext context) {
+      builder: (BuildContext dialogueContext) {
         return WillPopScope(
           onWillPop: () => Future.value(false),
           child: Dialog(
@@ -299,7 +338,7 @@ class _IdentityVerificationScreenState
                     child: const Text('Cancel')),
                 TextButton(
                     onPressed: () async {
-                      _loadingDialog();
+                      await loadingDialog();
 
                       String emailValue = controller.text.toLowerCase().trim();
                       bool isValidEmail = validateEmail(emailValue);
@@ -393,7 +432,7 @@ class _IdentityVerificationScreenState
     if (phoneVerified) {
       return;
     }
-    await PhoneAlertDialogState().sendPhoneVerification();
+    await sendPhoneVerification();
     setState(() {});
   }
 
@@ -459,7 +498,7 @@ class _IdentityVerificationScreenState
                       await verifyEmail();
                       getEmailCountdown(startNew: true);
                     } else {
-                      _loadingDialog();
+                      await loadingDialog();
                       await verifyPhone();
                       Navigator.pop(context);
                       getPhoneCountdown();
@@ -500,7 +539,7 @@ class _IdentityVerificationScreenState
     }
 
     if (step == 2 && phoneCountdownNotifier.value == -1) {
-      await addPhoneNumberDialog(context, newPhone: false, oldPhone: phone);
+      await addPhoneNumberDialog(context, newPhone: false, oldPhone: phone, onVerify: verifyButton);
       var phoneMap = await getPhone();
       String? phoneNumber = phoneMap['phone'];
       setState(() {
@@ -552,7 +591,7 @@ class _IdentityVerificationScreenState
                   ],
                 ),
               ),
-              isVerified ? const Icon(Icons.edit) : _buildVerificationBtn(step),
+              isVerified || text == 'Unknown' ? const Icon(Icons.edit) : _buildVerificationBtn(step),
             ],
           ),
         ),

--- a/app/lib/screens/identity_verification_screen.dart
+++ b/app/lib/screens/identity_verification_screen.dart
@@ -4,20 +4,16 @@ import 'dart:core';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_pkid/flutter_pkid.dart';
-import 'package:http/http.dart';
 import 'package:threebotlogin/helpers/globals.dart';
-import 'package:threebotlogin/helpers/kyc_helpers.dart';
 import 'package:threebotlogin/helpers/logger.dart';
 import 'package:threebotlogin/main.dart';
 import 'package:threebotlogin/screens/authentication_screen.dart';
-import 'package:threebotlogin/services/gridproxy_service.dart';
 import 'package:threebotlogin/services/identity_service.dart';
 import 'package:threebotlogin/services/open_kyc_service.dart';
 import 'package:threebotlogin/services/pkid_service.dart';
 import 'package:threebotlogin/services/tools_service.dart';
 import 'package:threebotlogin/services/shared_preference_service.dart';
 import 'package:threebotlogin/widgets/custom_dialog.dart';
-import 'package:threebotlogin/widgets/kyc_widget.dart';
 import 'package:threebotlogin/widgets/layout_drawer.dart';
 import 'package:threebotlogin/widgets/phone_widget.dart';
 
@@ -31,37 +27,48 @@ class IdentityVerificationScreen extends StatefulWidget {
 
 class _IdentityVerificationScreenState
     extends State<IdentityVerificationScreen> {
+  final emailController = TextEditingController();
+  final changeEmailController = TextEditingController();
+  Globals globals = Globals();
   String doubleName = '';
   String phrase = '';
   String email = '';
   String phone = '';
-
   String reference = '';
-
   bool emailVerified = false;
   bool phoneVerified = false;
-
   bool isLoading = false;
-
   bool hidePhoneVerifyButton = false;
-
-  Globals globals = Globals();
-
-  final emailController = TextEditingController();
-  final changeEmailController = TextEditingController();
   bool emailInputValidated = false;
-
-  double spending = 0.0;
-
   int emailCountdown = 60;
-  Timer? emailTimer;
-  ValueNotifier<int> countdownNotifier = ValueNotifier(-1);
-
   int phoneCountdown = 120;
+  Timer? emailTimer;
   Timer? phoneTimer;
+  ValueNotifier<int> countdownNotifier = ValueNotifier(-1);
   ValueNotifier<int> phoneCountdownNotifier = ValueNotifier(-1);
 
-  void startOrResumePhoneCountdown() {
+  @override
+  void initState() {
+    super.initState();
+    Globals().emailVerified.addListener(setEmailVerified);
+    Globals().phoneVerified.addListener(setPhoneVerified);
+    checkPhoneStatus();
+    getUserValues();
+    getEmailCountdown();
+    getPhoneCountdown();
+  }
+
+  @override
+  void dispose() {
+    emailTimer?.cancel();
+    phoneTimer?.cancel();
+    phoneCountdownNotifier.dispose();
+    countdownNotifier.dispose();
+    super.dispose();
+  }
+
+  void getPhoneCountdown() {
+    print('countdown entered');
     int currentTime = DateTime.now().millisecondsSinceEpoch;
     int lockedUntil =
         Globals().smsSentOn + (Globals().smsMinutesCoolDown * 60 * 1000);
@@ -90,7 +97,7 @@ class _IdentityVerificationScreenState
     }
   }
 
-  void startOrResumeEmailCountdown({bool startNew = false}) {
+  void getEmailCountdown({bool startNew = false}) {
     int currentTime = DateTime.now().millisecondsSinceEpoch;
     int lockedUntil =
         Globals().emailSentOn + (Globals().emailMinutesCoolDown * 60 * 1000);
@@ -150,185 +157,33 @@ class _IdentityVerificationScreenState
     }
   }
 
-  @override
-  void initState() {
-    super.initState();
-
-    Globals().emailVerified.addListener(setEmailVerified);
-    Globals().phoneVerified.addListener(setPhoneVerified);
-    checkPhoneStatus();
-    getUserValues();
-    startOrResumeEmailCountdown();
-    startOrResumePhoneCountdown();
-  }
-
-  @override
-  void dispose() {
-    emailTimer?.cancel();
-    phoneTimer?.cancel();
-    phoneCountdownNotifier.dispose();
-    countdownNotifier.dispose();
-    super.dispose();
-  }
-
   checkPhoneStatus() {
-    int currentTime = DateTime.now().millisecondsSinceEpoch;
-    int lockedUntil =
-        Globals().smsSentOn + (Globals().smsMinutesCoolDown * 60 * 1000);
-
-    if (lockedUntil > currentTime) {
-      return Globals().hidePhoneButton.value = true;
-    } else if (phoneCountdownNotifier.value <= 0) {
-      return Globals().hidePhoneButton.value = false;
+    if (phoneCountdownNotifier.value <= 0) {
+      Globals().hidePhoneButton.value = false;
+    } else {
+      Globals().hidePhoneButton.value = true;
     }
   }
 
-  void getUserValues() {
-    getDoubleName().then((dn) {
-      setState(() {
-        doubleName = dn!;
-      });
-    });
-    getPhrase().then((seedPhrase) {
-      setState(() {
-        phrase = seedPhrase!;
-      });
-    });
-    getEmail().then((emailMap) {
-      setState(() {
-        if (emailMap['email'] != null) {
-          email = emailMap['email']!;
-          changeEmailController.text = email;
-          emailVerified = (emailMap['sei'] != null);
-        }
-      });
-    });
-    getPhone().then((phoneMap) {
-      setState(() {
-        if (phoneMap['phone'] != null) {
-          phone = phoneMap['phone']!;
-          phoneVerified = (phoneMap['spi'] != null);
-        }
-      });
-    });
-    getSpending();
-  }
-
-  Widget customDivider({
-    required BuildContext context,
-  }) {
-    return Center(
-      child: SizedBox(
-        width: MediaQuery.of(context).size.width * 0.85,
-        child: const Divider(
-          thickness: 0.5,
-          color: Colors.grey,
-        ),
-      ),
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    startOrResumePhoneCountdown();
-    return LayoutDrawer(
-      titleText: 'Identity',
-      content: FutureBuilder(
-        future: getEmail(),
-        builder: (ctx, snapshot) {
-          if (snapshot.connectionState == ConnectionState.done) {
-            if (isLoading) {
-              return pleaseWait(context);
-            }
-            return Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 4.0),
-                child: SingleChildScrollView(
-                  child: Column(
-                    children: [
-                      const SizedBox(height: 20),
-                      AnimatedBuilder(
-                          animation: Listenable.merge([
-                            Globals().emailVerified,
-                            Globals().phoneVerified,
-                          ]),
-                          builder: (BuildContext context, _) {
-                            return Column(
-                              children: [
-                                ListTile(
-                                  leading: const Icon(Icons.person),
-                                  title: Text(
-                                    doubleName.isNotEmpty
-                                        ? doubleName.substring(
-                                            0, doubleName.length - 5)
-                                        : 'Unknown',
-                                  ),
-                                ),
-                                customDivider(context: context),
-                                FutureBuilder(
-                                  future: getPhrase(),
-                                  builder: (context, snapshot) {
-                                    if (snapshot.hasData) {
-                                      return Padding(
-                                        padding:
-                                            const EdgeInsets.only(right: 2.0),
-                                        child: ListTile(
-                                          trailing:
-                                              const Icon(Icons.visibility),
-                                          leading: const Icon(Icons.vpn_key),
-                                          title: const Text('Show phrase'),
-                                          onTap: () async {
-                                            _showPhrase();
-                                          },
-                                        ),
-                                      );
-                                    } else {
-                                      return Container();
-                                    }
-                                  },
-                                ),
-                                customDivider(context: context),
-
-                                // Step one: verify email
-                                _fillCard(
-                                    getCorrectState(
-                                        1, emailVerified, phoneVerified),
-                                    1,
-                                    email,
-                                    Icons.email),
-                                customDivider(context: context),
-
-                                // Step two: verify phone
-                                (Globals().phoneVerification == true ||
-                                        (Globals().spendingLimit > 0 &&
-                                            spending > Globals().spendingLimit))
-                                    ? _fillCard(
-                                        getCorrectState(
-                                            2, emailVerified, phoneVerified),
-                                        2,
-                                        phone,
-                                        Icons.phone)
-                                    : Container(),
-                                customDivider(context: context),
-                                const ListTile(
-                                  leading: Icon(Icons.info),
-                                  title: Text(
-                                      'KYC Verification has been moved to wallet page.'),
-                                ),
-                              ],
-                            );
-                          })
-                    ],
-                  ),
-                ));
-          }
-          return pleaseWait(context);
-        },
-      ),
-    );
+  void getUserValues() async {
+    doubleName = (await getDoubleName())!.replaceAll('.3bot', '') ?? 'Unknown';
+    phrase = (await getPhrase())!;
+    final emailMap = await getEmail();
+    if (emailMap['email'] != null) {
+      email = emailMap['email']!;
+      changeEmailController.text = email;
+      emailVerified = (emailMap['sei'] != null);
+    }
+    final phoneMap = await getPhone();
+    if (phoneMap['phone'] != null) {
+      phone = phoneMap['phone']!;
+      phoneVerified = (phoneMap['spi'] != null);
+    }
+    setState(() {});
   }
 
   Future copySeedPhrase() async {
-    Clipboard.setData(ClipboardData(text: (await getPhrase()).toString()));
+    Clipboard.setData(ClipboardData(text: phrase));
 
     const seedCopied = SnackBar(
       content: Text('Seed phrase copied to clipboard'),
@@ -350,17 +205,14 @@ class _IdentityVerificationScreenState
         ));
 
     if (authenticated != null && authenticated) {
-      final phrase = await getPhrase();
-
       showDialog(
         context: context,
         builder: (BuildContext context) => CustomDialog(
           hiddenAction: copySeedPhrase,
           image: Icons.info,
           title: 'Please write this down on a piece of paper',
-          description: phrase.toString(),
+          description: phrase,
           actions: <Widget>[
-            // usually buttons at the bottom of the dialog
             TextButton(
               child: const Text('Close'),
               onPressed: () {
@@ -381,29 +233,25 @@ class _IdentityVerificationScreenState
         return WillPopScope(
           onWillPop: () => Future.value(false),
           child: Dialog(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const SizedBox(
-                  height: 10,
-                ),
-                CircularProgressIndicator(
-                  color: Theme.of(context).colorScheme.primary,
-                ),
-                const SizedBox(
-                  height: 10,
-                ),
-                Text(
-                  'One moment please',
-                  style: Theme.of(context)
-                      .textTheme
-                      .bodyMedium!
-                      .copyWith(color: Theme.of(context).colorScheme.onSurface),
-                ),
-                const SizedBox(
-                  height: 10,
-                ),
-              ],
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const SizedBox(height: 10),
+                  CircularProgressIndicator(
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                  const SizedBox(height: 10),
+                  Text(
+                    'One moment please...',
+                    style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                          color: Theme.of(context).colorScheme.onSurface,
+                        ),
+                  ),
+                  const SizedBox(height: 10),
+                ],
+              ),
             ),
           ),
         );
@@ -411,273 +259,384 @@ class _IdentityVerificationScreenState
     );
   }
 
-  Widget _fillCard(String phase, int step, String text, IconData icon) {
-    switch (phase) {
-      case 'Unverified':
-        {
-          return unVerifiedWidget(step, text, icon);
-        }
+  void _changeEmailDialog() {
+    TextEditingController controller = TextEditingController();
+    bool validEmail = false;
+    String? errorEmail;
+    Text statusMessage = const Text('');
 
-      case 'Verified':
-        {
-          return verifiedWidget(step, text, icon);
-        }
+    showDialog(
+        context: context,
+        builder: (BuildContext dialogContext) {
+          return StatefulBuilder(builder: (statefulContext, setCustomState) {
+            return AlertDialog(
+              title: Text('Change email',
+                  style: Theme.of(context).textTheme.headlineMedium!.copyWith(
+                      color: Theme.of(context).colorScheme.onSurface)),
+              contentPadding: const EdgeInsets.all(24),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                      'Changing your email will require re-\u200dverification.',
+                      style: Theme.of(context).textTheme.bodyLarge!.copyWith(
+                          color: Theme.of(context).colorScheme.onSurface)),
+                  TextField(
+                    controller: controller,
+                    style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                          color: Theme.of(context).colorScheme.onSurface,
+                        ),
+                    decoration: InputDecoration(
+                        labelText: 'Email',
+                        errorText: validEmail ? null : errorEmail),
+                  ),
+                  const SizedBox(
+                    height: 20,
+                  ),
+                  statusMessage
+                ],
+              ),
+              actions: [
+                TextButton(
+                    onPressed: () {
+                      Navigator.pop(dialogContext);
+                    },
+                    child: const Text('Cancel')),
+                TextButton(
+                    onPressed: () async {
+                      _loadingDialog();
 
-      case 'CurrentPhase':
-        {
-          return currentPhaseWidget(step, text, icon);
-        }
+                      String emailValue = controller.text.toLowerCase().trim();
+                      bool isValidEmail = validateEmail(emailValue);
 
-      default:
-        {
-          return Container();
-        }
-    }
+                      var oldEmail = await getEmail();
+
+                      if (oldEmail['email'] == emailValue) {
+                        validEmail = false;
+                        errorEmail = 'Please enter a different email';
+                        setCustomState(() {});
+                        Navigator.pop(context);
+                        return;
+                      }
+
+                      if (isValidEmail == false) {
+                        validEmail = false;
+                        errorEmail = 'Please enter a valid email';
+                        setCustomState(() {});
+                        Navigator.pop(context);
+                        return;
+                      }
+
+                      try {
+                        errorEmail = null;
+                        await saveEmail(emailValue, null);
+                        await updateEmailAddressOfUser();
+
+                        sendVerificationEmail();
+
+                        email = emailValue;
+
+                        await setIsEmailVerified(false);
+                        await saveEmailToPKid();
+
+                        Navigator.pop(context);
+                        Navigator.pop(dialogContext);
+                        resendEmailDialog(context);
+                        getEmailCountdown(startNew: true);
+
+                        setState(() {});
+                      } catch (e) {
+                        logger.e(e);
+                        Navigator.pop(context);
+
+                        statusMessage = const Text('Something went wrong',
+                            style: TextStyle(
+                                color: Colors.red,
+                                fontWeight: FontWeight.bold));
+
+                        setState(() {});
+                        setCustomState(() {});
+                      }
+                    },
+                    child: const Text('Ok'))
+              ],
+            );
+          });
+        });
   }
 
-  Widget unVerifiedWidget(step, text, icon) {
-    return GestureDetector(
-      onTap: () async {},
-      child: Opacity(
-        opacity: 0.5,
-        child: Column(
-          children: [
-            Padding(
-              padding: const EdgeInsets.only(bottom: 10.0),
-              child: ListTile(
-                leading: Icon(icon),
-                title: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Row(
-                      children: <Widget>[
-                        Expanded(
-                          child: Text(
-                            text == '' ? 'Unknown' : text,
-                            overflow: TextOverflow.clip,
-                            style: TextStyle(
-                              fontWeight: FontWeight.bold,
-                              color: Theme.of(context).colorScheme.onSurface,
-                            ),
-                          ),
-                        )
-                      ],
-                    ),
-                    const SizedBox(
-                      height: 5,
-                    ),
-                    Row(
-                      children: <Widget>[
-                        Icon(
-                          Icons.close,
-                          color: Theme.of(context).colorScheme.error,
-                          size: 18.0,
-                        ),
-                        const SizedBox(width: 5),
-                        Text(
-                          'Not verified',
-                          style: TextStyle(
-                            color: Theme.of(context).colorScheme.error,
-                            fontWeight: FontWeight.bold,
-                            fontSize: 12,
-                          ),
-                        )
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ],
+  Future<dynamic> resendEmailDialog(context) {
+    return showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) => CustomDialog(
+        image: Icons.check,
+        title: 'Email has been resent.',
+        description: 'A verification email has been sent.',
+        actions: <Widget>[
+          TextButton(
+            child: const Text('Close'),
+            onPressed: () {
+              Navigator.pop(context);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  void verifyEmail() {
+    if (emailVerified) {
+      return;
+    }
+
+    if (countdownNotifier.value == -1) {
+      return _changeEmailDialog();
+    }
+
+    sendVerificationEmail();
+    resendEmailDialog(context);
+  }
+
+  Future<void> verifyPhone() async {
+    if (phoneVerified) {
+      return;
+    }
+    getPhoneCountdown();
+
+    await PhoneAlertDialogState().sendPhoneVerification();
+    setState(() {});
+  }
+
+  Widget customDivider({
+    required BuildContext context,
+  }) {
+    return Center(
+      child: SizedBox(
+        width: MediaQuery.of(context).size.width * 0.85,
+        child: const Divider(
+          thickness: 0.5,
+          color: Colors.grey,
         ),
       ),
     );
   }
 
-  Widget currentPhaseWidget(step, text, icon) {
-    return GestureDetector(
-        onTap: () async {
-          if (step == 1 && countdownNotifier.value == -1) {
-            return _changeEmailDialog(false);
-          }
+  Widget _fillCard(String phase, int step, String text, IconData icon) {
+    switch (phase) {
+      case 'Unverified':
+        return unVerifiedWidget(step, text, icon);
+      case 'Verified':
+        return verifiedWidget(step, text, icon);
+      case 'CurrentPhase':
+        return currentPhaseWidget(step, text, icon);
+      default:
+        return Container();
+    }
+  }
 
-          if (step == 2 && phoneCountdownNotifier.value == -1) {
-            if (phone.isEmpty) {
-              await addPhoneNumberDialog(context, newPhone: true, oldPhone: '');
-            } else {
-              await addPhoneNumberDialog(context,
-                  newPhone: false, oldPhone: phone);
-            }
-
-            var phoneMap = (await getPhone());
-            if (phoneMap.isEmpty || !phoneMap.containsKey('phone')) {
-              return;
-            }
-
-            String? phoneNumber = phoneMap['phone'];
-            if (phoneNumber == null || phoneNumber.isEmpty) {
-              return;
-            }
-
-            setState(() {
-              phone = phoneNumber;
-            });
-
-            FlutterPkid client = await getPkidClient();
-            client.setPKidDoc('phone', json.encode({'phone': phone}));
-
-            if (phone.isEmpty) {
-              return;
-            }
-          }
-        },
-        child: Column(children: [
-          Padding(
-              padding: const EdgeInsets.only(bottom: 10.0),
-              child: ListTile(
-                leading: Icon(icon),
-                title: Row(
-                  mainAxisSize: MainAxisSize.min,
+  Widget unVerifiedWidget(int step, String text, IconData icon) {
+    return InkWell(
+      child: Opacity(
+        opacity: 0.5,
+        child: Padding(
+          padding: const EdgeInsets.only(bottom: 10.0),
+          child: ListTile(
+            leading: Icon(icon),
+            title: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
                   children: [
-                    Flexible(
-                        child: Container(
-                            constraints: Globals().hidePhoneButton.value ==
-                                        false ||
-                                    (step != 2 &&
-                                        Globals().hidePhoneButton.value == true)
-                                ? BoxConstraints(
-                                    minWidth:
-                                        MediaQuery.of(context).size.width * 0.5,
-                                    maxWidth:
-                                        MediaQuery.of(context).size.width * 0.5)
-                                : BoxConstraints(
-                                    minWidth:
-                                        MediaQuery.of(context).size.width * 0.7,
-                                    maxWidth:
-                                        MediaQuery.of(context).size.width *
-                                            0.7),
-                            child: Column(
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                children: <Widget>[
-                                  Row(
-                                    children: <Widget>[
-                                      Expanded(
-                                        child: Text(
-                                          (text.isEmpty ? 'Unknown' : text),
-                                        ),
-                                      )
-                                    ],
-                                  ),
-                                  if (step == 1)
-                                    ValueListenableBuilder<int>(
-                                      valueListenable: countdownNotifier,
-                                      builder:
-                                          (context, countdownValue, child) {
-                                        if (countdownValue > 0) {
-                                          return Row(
-                                            children: <Widget>[
-                                              Expanded(
-                                                child: Text(
-                                                  'Verification email sent, retry in $countdownValue second${countdownValue == 1 ? '' : 's'}',
-                                                  overflow: TextOverflow.clip,
-                                                  style: Theme.of(context)
-                                                      .textTheme
-                                                      .bodySmall!
-                                                      .copyWith(
-                                                          fontWeight:
-                                                              FontWeight.bold,
-                                                          color:
-                                                              Theme.of(context)
-                                                                  .colorScheme
-                                                                  .warning),
-                                                ),
-                                              ),
-                                            ],
-                                          );
-                                        } else {
-                                          return Container();
-                                        }
-                                      },
-                                    ),
-                                  if (step == 2)
-                                    ValueListenableBuilder<bool>(
-                                      valueListenable:
-                                          Globals().hidePhoneButton,
-                                      builder:
-                                          (context, hidePhoneButton, child) {
-                                        if (hidePhoneButton) {
-                                          return Column(
-                                            children: [
-                                              const SizedBox(height: 5),
-                                              Row(
-                                                children: <Widget>[
-                                                  ValueListenableBuilder<int>(
-                                                    valueListenable:
-                                                        phoneCountdownNotifier,
-                                                    builder: (context,
-                                                        remainingTime, child) {
-                                                      if (remainingTime > 0) {
-                                                        String formattedTime =
-                                                            _formatTime(
-                                                                remainingTime);
-                                                        return Text(
-                                                          'SMS sent, retry in $formattedTime',
-                                                          style:
-                                                              Theme.of(context)
-                                                                  .textTheme
-                                                                  .bodySmall!
-                                                                  .copyWith(
-                                                                    fontWeight:
-                                                                        FontWeight
-                                                                            .bold,
-                                                                    color: Theme.of(
-                                                                            context)
-                                                                        .colorScheme
-                                                                        .warning,
-                                                                  ),
-                                                        );
-                                                      }
-                                                      return Container();
-                                                    },
-                                                  ),
-                                                ],
-                                              ),
-                                            ],
-                                          );
-                                        }
-                                        return Container();
-                                      },
-                                    ),
-                                ]))),
-                    ValueListenableBuilder<int>(
-                      valueListenable: step == 1
-                          ? countdownNotifier
-                          : phoneCountdownNotifier,
-                      builder: (context, countdownValue, child) {
-                        return Padding(
-                          padding: const EdgeInsets.only(left: 12),
-                          child: ElevatedButton(
-                            onPressed: countdownValue > 0
-                                ? null
-                                : () async {
-                                    if (step == 1) {
-                                      startOrResumeEmailCountdown(
-                                          startNew: true);
-                                      verifyEmail();
-                                    } else if (step == 2) {
-                                      await verifyPhone();
-                                    }
-                                  },
-                            child: const Text('Resend'),
-                          ),
-                        );
-                      },
+                    Expanded(
+                      child: Text(
+                        text.isEmpty ? 'Unknown' : text,
+                        overflow: TextOverflow.clip,
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          color: Theme.of(context).colorScheme.onSurface,
+                        ),
+                      ),
                     ),
                   ],
                 ),
-              ))
-        ]));
+                const SizedBox(height: 5),
+                Row(
+                  children: [
+                    Icon(
+                      Icons.close,
+                      color: Theme.of(context).colorScheme.error,
+                      size: 18.0,
+                    ),
+                    const SizedBox(width: 5),
+                    Text(
+                      'Not verified',
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.error,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget currentPhaseWidget(int step, String text, IconData icon) {
+    return InkWell(
+      onTap: () async {
+        if (step == 1 && countdownNotifier.value == -1) {
+          return _changeEmailDialog();
+        }
+
+        if (step == 2 && phoneCountdownNotifier.value == -1) {
+          if (phone.isEmpty) {
+            await addPhoneNumberDialog(context, newPhone: true, oldPhone: '');
+          } else {
+            await addPhoneNumberDialog(context,
+                newPhone: false, oldPhone: phone);
+          }
+
+          var phoneMap = await getPhone();
+          if (phoneMap.isEmpty || !phoneMap.containsKey('phone')) {
+            return;
+          }
+
+          String? phoneNumber = phoneMap['phone'];
+          if (phoneNumber == null || phoneNumber.isEmpty) {
+            return;
+          }
+
+          setState(() {
+            phone = phoneNumber;
+          });
+
+          FlutterPkid client = await getPkidClient();
+          client.setPKidDoc('phone', json.encode({'phone': phone}));
+
+          if (phone.isEmpty) {
+            return;
+          }
+        }
+      },
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(bottom: 10.0),
+            child: ListTile(
+              leading: Icon(icon),
+              title: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Flexible(
+                    child: Container(
+                      constraints: _getConstraints(context, step),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Row(
+                            children: [
+                              Expanded(
+                                child: Text(
+                                  text.isEmpty ? 'Unknown' : text,
+                                  overflow: TextOverflow.clip,
+                                ),
+                              ),
+                            ],
+                          ),
+                          if (step == 1) _buildCountdown(context, true),
+                          if (step == 2) _buildCountdown(context, false),
+                        ],
+                      ),
+                    ),
+                  ),
+                  _buildVerificationBtn(step),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  BoxConstraints _getConstraints(BuildContext context, int step) {
+    final hidePhoneButton = Globals().hidePhoneButton.value;
+    final screenWidth = MediaQuery.of(context).size.width;
+
+    if (hidePhoneButton == false || (step != 2 && hidePhoneButton == true)) {
+      return BoxConstraints(
+        minWidth: screenWidth * 0.5,
+        maxWidth: screenWidth * 0.5,
+      );
+    } else {
+      return BoxConstraints(
+        minWidth: screenWidth * 0.7,
+        maxWidth: screenWidth * 0.7,
+      );
+    }
+  }
+
+  formatCountdownMsg(bool isEmail, int countdownValue) {
+    if (isEmail) {
+      return 'Verification email sent, retry in $countdownValue second${countdownValue == 1 ? '' : 's'}';
+    }
+
+    return 'SMS sent, retry in ${_formatTime(countdownValue)}';
+  }
+
+  Widget _buildCountdown(BuildContext context, bool isEmail) {
+    return ValueListenableBuilder<int>(
+      valueListenable: isEmail ? countdownNotifier : phoneCountdownNotifier,
+      builder: (context, countdownValue, child) {
+        if (countdownValue > 0) {
+          return Row(
+            children: [
+              Expanded(
+                child: Text(
+                  formatCountdownMsg(isEmail, countdownValue),
+                  style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: Theme.of(context).colorScheme.warning,
+                      ),
+                ),
+              ),
+            ],
+          );
+        }
+        return Container();
+      },
+    );
+  }
+
+  Widget _buildVerificationBtn(int step) {
+    return ValueListenableBuilder<int>(
+      valueListenable: step == 1 ? countdownNotifier : phoneCountdownNotifier,
+      builder: (context, countdownValue, child) {
+        return Padding(
+          padding: const EdgeInsets.only(left: 20),
+          child: ElevatedButton(
+            onPressed: countdownValue > 0
+                ? null
+                : () async {
+                    if (step == 1) {
+                      getEmailCountdown(startNew: true);
+                      verifyEmail();
+                    } else {
+                      getPhoneCountdown();
+                      await verifyPhone();
+                    }
+                  },
+            child: Text(step == 1 ? 'Resend' : 'Verify'),
+          ),
+        );
+      },
+    );
   }
 
   String _formatTime(int remainingTime) {
@@ -702,395 +661,108 @@ class _IdentityVerificationScreenState
     return '0';
   }
 
-  Widget verifiedWidget(step, text, icon) {
-    return GestureDetector(
-        onTap: () async {
-          if (step == 1) {
-            return _changeEmailDialog(false);
-          }
-          if (step == 2) {
-            await addPhoneNumberDialog(context,
-                newPhone: false, oldPhone: phone);
-            var phoneMap = (await getPhone());
-            String? phoneNumber = phoneMap['phone'];
-            if (phone != phoneNumber) {
-              setState(() {
-                phone = phoneNumber!;
-              });
-            }
-            return;
-          }
-        },
-        child: Column(children: [
-          Padding(
-              padding: const EdgeInsets.only(bottom: 10.0),
-              child: ListTile(
-                leading: Icon(icon),
-                title: Row(
-                  children: [
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Row(
-                              children: [
-                                Container(
-                                    constraints: BoxConstraints(
-                                        minWidth:
-                                            MediaQuery.of(context).size.width *
-                                                0.65,
-                                        maxWidth:
-                                            MediaQuery.of(context).size.width *
-                                                0.65),
-                                    child: Text(
-                                      text == '' ? 'Unknown' : text,
-                                      overflow: TextOverflow.clip,
-                                    ))
-                              ],
-                            ),
-                            const SizedBox(height: 5),
-                            Row(
-                              children: [
-                                Text(
-                                  'Verified',
-                                  style: Theme.of(context)
-                                      .textTheme
-                                      .bodySmall!
-                                      .copyWith(
-                                          color: Theme.of(context)
-                                              .colorScheme
-                                              .primary,
-                                          fontWeight: FontWeight.bold),
-                                )
-                              ],
-                            )
-                          ],
-                        ),
-                        step == 1
-                            ? const Column(
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                children: [
-                                    Padding(
-                                      padding: EdgeInsets.only(left: 15),
-                                      child: Icon(
-                                        Icons.edit,
-                                      ),
-                                    ),
-                                  ])
-                            : const Column(),
-                        step == 2
-                            ? const Column(
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                children: [
-                                    Padding(
-                                      padding: EdgeInsets.only(left: 15),
-                                      child: Icon(
-                                        Icons.edit,
-                                      ),
-                                    ),
-                                  ])
-                            : const Column(),
-                      ],
+  Widget verifiedWidget(int step, String text, IconData icon) {
+    return InkWell(
+      onTap: () async {
+        if (step == 1) {
+          _changeEmailDialog();
+        } else {
+          await addPhoneNumberDialog(context, newPhone: false, oldPhone: phone);
+          var phoneMap = await getPhone();
+          String? phoneNumber = phoneMap['phone'];
+          setState(() {
+            phone = phoneNumber!;
+          });
+        }
+      },
+      child: Padding(
+        padding: const EdgeInsets.only(
+          bottom: 10.0,
+        ),
+        child: ListTile(
+          leading: Icon(icon),
+          title: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    constraints: BoxConstraints(
+                      minWidth: MediaQuery.of(context).size.width * 0.65,
+                      maxWidth: MediaQuery.of(context).size.width * 0.65,
                     ),
-                  ],
-                ),
-              ))
-        ]));
-  }
-
-  Future<dynamic> resendEmailDialog(context) {
-    return showDialog(
-      context: context,
-      barrierDismissible: false,
-      builder: (BuildContext context) => CustomDialog(
-        image: Icons.check,
-        title: 'Email has been resent.',
-        description: 'A verification email has been sent.',
-        actions: <Widget>[
-          TextButton(
-            child: const Text('Close'),
-            onPressed: () {
-              Navigator.pop(context);
-            },
+                    child: Text(
+                      text.isEmpty ? 'Unknown' : text,
+                      overflow: TextOverflow.clip,
+                    ),
+                  ),
+                  const SizedBox(height: 5),
+                  Text(
+                    'Verified',
+                    style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                          color: Theme.of(context).colorScheme.primary,
+                          fontWeight: FontWeight.bold,
+                        ),
+                  ),
+                ],
+              ),
+              const Icon(Icons.edit),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }
 
-  void _changeEmailDialog(bool emailWasEmpty) {
-    TextEditingController controller = TextEditingController();
-
-    bool validEmail = false;
-    String? errorEmail;
-    Text statusMessage = const Text('');
-
-    showDialog(
-        context: context,
-        builder: (BuildContext dialogContext) {
-          return StatefulBuilder(builder: (statefulContext, setCustomState) {
-            return AlertDialog(
-              title: emailWasEmpty == true
-                  ? Text(
-                      'Add email',
-                      style: Theme.of(context)
-                          .textTheme
-                          .headlineMedium!
-                          .copyWith(
-                              color: Theme.of(context).colorScheme.onSurface),
-                    )
-                  : Text('Change email',
-                      style: Theme.of(context)
-                          .textTheme
-                          .headlineMedium!
-                          .copyWith(
-                              color: Theme.of(context).colorScheme.onSurface)),
-              contentPadding: const EdgeInsets.all(24),
-              content: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  emailWasEmpty == true
-                      ? Text('Please pass us your email address',
-                          style: Theme.of(context)
-                              .textTheme
-                              .bodyLarge!
-                              .copyWith(
-                                  color:
-                                      Theme.of(context).colorScheme.onSurface))
-                      : Text(
-                          'Changing your email will require re-\u200dverification.',
-                          style: Theme.of(context)
-                              .textTheme
-                              .bodyLarge!
-                              .copyWith(
-                                  color:
-                                      Theme.of(context).colorScheme.onSurface)),
-                  TextField(
-                    controller: controller,
-                    style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onSurface,
-                        ),
-                    decoration: InputDecoration(
-                        labelText: 'Email',
-                        errorText: validEmail == true ? null : errorEmail),
-                  ),
-                  const SizedBox(
-                    height: 20,
-                  ),
-                  statusMessage
-                ],
-              ),
-              actions: [
-                TextButton(
-                    onPressed: () {
-                      Navigator.pop(dialogContext);
-                    },
-                    child: const Text('Cancel')),
-                TextButton(
-                    onPressed: () async {
-                      _loadingDialog();
-
-                      String emailValue = controller.text
-                          .toLowerCase()
-                          .trim()
-                          .replaceAll(RegExp(r'\s+'), ' ');
-                      bool isValidEmail = validateEmail(emailValue);
-
-                      var oldEmail = await getEmail();
-
-                      if (oldEmail['email'] == emailValue) {
-                        validEmail = false;
-                        errorEmail = 'Please enter a different email';
-                        setCustomState(() {});
-                        Navigator.pop(context);
-                        return;
-                      }
-
-                      if (isValidEmail == false) {
-                        validEmail = false;
-                        errorEmail = 'Please enter a valid email';
-                        setCustomState(() {});
-                        Navigator.pop(context);
-                        return;
-                      }
-
-                      try {
-                        errorEmail = null;
-                        await saveEmail(emailValue, null);
-
-                        Response res = await updateEmailAddressOfUser();
-
-                        if (res.statusCode != 200) {
-                          throw Exception();
-                        }
-
-                        sendVerificationEmail();
-
-                        email = emailValue;
-
-                        await setIsEmailVerified(false);
-                        await saveEmailToPKid();
-
-                        Navigator.pop(context);
-                        Navigator.pop(dialogContext);
-                        resendEmailDialog(context);
-                        startOrResumeEmailCountdown(startNew: true);
-
-                        setState(() {});
-                      } catch (e) {
-                        logger.e(e);
-                        Navigator.pop(context);
-
-                        await saveEmail(oldEmail['email']!, oldEmail['sei']);
-                        await saveEmailToPKid();
-
-                        statusMessage = const Text('Something went wrong',
-                            style: TextStyle(
-                                color: Colors.red,
-                                fontWeight: FontWeight.bold));
-
-                        setState(() {});
-                        setCustomState(() {});
-                      }
-                    },
-                    child: const Text('Ok'))
-              ],
-            );
-          });
-        });
-  }
-
-  Future<dynamic> showEmailChangeDialog() async {
-    FlutterPkid client = await getPkidClient();
-
-    var emailPKidResult = await client.getPKidDoc('email');
-    logger.i(emailPKidResult);
-    return showDialog(
-      context: context,
-      builder: (BuildContext context) {
-        return AlertDialog(
-          title: const Text('Change your email'),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
+  @override
+  Widget build(BuildContext context) {
+    return LayoutDrawer(
+      titleText: 'Identity',
+      content: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4.0),
+        child: SingleChildScrollView(
+          child: Column(
             children: [
-              const Text('Please pass us your email address'),
-              const SizedBox(height: 16),
-              TextField(
-                controller: changeEmailController,
-                decoration: InputDecoration(
-                    labelText: 'Email',
-                    errorText: emailInputValidated
-                        ? null
-                        : 'Please enter a valid email'),
+              const SizedBox(height: 20),
+              AnimatedBuilder(
+                animation: Listenable.merge([
+                  Globals().emailVerified,
+                  Globals().phoneVerified,
+                ]),
+                builder: (BuildContext context, _) {
+                  final emailState =
+                      getCorrectState(1, emailVerified, phoneVerified);
+                  final phoneState =
+                      getCorrectState(2, emailVerified, phoneVerified);
+                  return Column(
+                    children: [
+                      ListTile(
+                        leading: const Icon(Icons.person),
+                        title: Text(doubleName),
+                      ),
+                      customDivider(context: context),
+                      Padding(
+                        padding: const EdgeInsets.only(right: 2.0),
+                        child: ListTile(
+                          trailing: const Icon(Icons.visibility),
+                          leading: const Icon(Icons.vpn_key),
+                          title: const Text('Show phrase'),
+                          onTap: _showPhrase,
+                        ),
+                      ),
+                      customDivider(context: context),
+                      _fillCard(emailState, 1, email, Icons.email),
+                      customDivider(context: context),
+                      _fillCard(phoneState, 2, phone, Icons.phone),
+                    ],
+                  );
+                },
               ),
             ],
           ),
-          actions: <Widget>[
-            TextButton(
-              child: const Text('OK'),
-              onPressed: () async {
-                bool isValid = checkEmail(changeEmailController.text);
-                if (!isValid) {
-                  setState(() {
-                    emailInputValidated = false;
-                  });
-                  return;
-                }
-
-                setState(() {
-                  emailInputValidated = true;
-                  email = changeEmailController.text;
-                });
-
-                await saveEmail(changeEmailController.text, null);
-
-                FlutterPkid client = await getPkidClient();
-
-                client.setPKidDoc('email', json.encode({'email': email}));
-
-                Navigator.of(context).pop();
-              },
-            ),
-          ],
-        );
-      },
-    );
-  }
-
-  void verifyEmail() {
-    if (emailVerified) {
-      return;
-    }
-
-    if (email == '' && countdownNotifier.value == -1) {
-      return _changeEmailDialog(true);
-    }
-
-    sendVerificationEmail();
-    resendEmailDialog(context);
-  }
-
-  Future verifyPhone() async {
-    if (phoneVerified) {
-      return;
-    }
-
-    if (phone.isEmpty) {
-      await addPhoneNumberDialog(context, newPhone: true, oldPhone: phone);
-
-      var phoneMap = (await getPhone());
-      if (phoneMap.isEmpty || !phoneMap.containsKey('phone')) {
-        return;
-      }
-      String? phoneNumber = phoneMap['phone'];
-      if (phoneNumber == null || phoneNumber.isEmpty) {
-        return;
-      }
-
-      setState(() {
-        phone = phoneNumber;
-      });
-
-      FlutterPkid client = await getPkidClient();
-      client.setPKidDoc('phone', json.encode({'phone': phone}));
-
-      return;
-    } else {
-      await PhoneAlertDialogState().sendPhoneVerification();
-      setState(() {});
-      return;
-    }
-  }
-
-  Future<void> getSpending() async {
-    if (Globals().spendingLimit <= 0) return;
-    try {
-      setState(() {
-        isLoading = true;
-      });
-      spending = await getMySpending();
-    } catch (e) {
-      final loadingSpendingFailure = SnackBar(
-        content: Text(
-          'Failed to load user spending',
-          style: Theme.of(context)
-              .textTheme
-              .bodyMedium!
-              .copyWith(color: Theme.of(context).colorScheme.errorContainer),
         ),
-        duration: const Duration(seconds: 3),
-      );
-      ScaffoldMessenger.of(context).clearSnackBars();
-      ScaffoldMessenger.of(context).showSnackBar(loadingSpendingFailure);
-      logger.e('Failed to load user spending due to $e');
-      spending = 0.0;
-    } finally {
-      setState(() {
-        isLoading = false;
-      });
-    }
+      ),
+    );
   }
 }

--- a/app/lib/screens/identity_verification_screen.dart
+++ b/app/lib/screens/identity_verification_screen.dart
@@ -45,6 +45,7 @@ class IdentityVerificationScreenState
   int phoneCountdown = 120;
   Timer? emailTimer;
   Timer? phoneTimer;
+  bool newPhone = false;
   ValueNotifier<int> emailCountdownNotifier = ValueNotifier(-1);
   ValueNotifier<int> phoneCountdownNotifier = ValueNotifier(-1);
 
@@ -531,7 +532,7 @@ class IdentityVerificationScreenState
     }
 
     if (step == 2 && phoneCountdownNotifier.value == -1) {
-      await addPhoneNumberDialog(context, newPhone: false, oldPhone: phone, onVerify: verifyButton);
+      await addPhoneNumberDialog(context, newPhone: newPhone, oldPhone: phone, onVerify: verifyButton);
       var phoneMap = await getPhone();
       String? phoneNumber = phoneMap['phone'];
       setState(() {
@@ -543,6 +544,7 @@ class IdentityVerificationScreenState
   Widget infoWidget(int step, String text, IconData icon, bool isVerified) {
     return InkWell(
       onTap: () async {
+        newPhone = text == 'Unknown';
         await _handleInfoWidget(step);
       },
       child: Padding(

--- a/app/lib/screens/identity_verification_screen.dart
+++ b/app/lib/screens/identity_verification_screen.dart
@@ -1,14 +1,11 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:core';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_pkid/flutter_pkid.dart';
 import 'package:threebotlogin/helpers/globals.dart';
 import 'package:threebotlogin/helpers/logger.dart';
 import 'package:threebotlogin/main.dart';
 import 'package:threebotlogin/screens/authentication_screen.dart';
-import 'package:threebotlogin/services/identity_service.dart';
 import 'package:threebotlogin/services/open_kyc_service.dart';
 import 'package:threebotlogin/services/pkid_service.dart';
 import 'package:threebotlogin/services/tools_service.dart';
@@ -44,7 +41,7 @@ class _IdentityVerificationScreenState
   int phoneCountdown = 120;
   Timer? emailTimer;
   Timer? phoneTimer;
-  ValueNotifier<int> countdownNotifier = ValueNotifier(-1);
+  ValueNotifier<int> emailCountdownNotifier = ValueNotifier(-1);
   ValueNotifier<int> phoneCountdownNotifier = ValueNotifier(-1);
 
   @override
@@ -63,7 +60,7 @@ class _IdentityVerificationScreenState
     emailTimer?.cancel();
     phoneTimer?.cancel();
     phoneCountdownNotifier.dispose();
-    countdownNotifier.dispose();
+    emailCountdownNotifier.dispose();
     super.dispose();
   }
 
@@ -110,7 +107,7 @@ class _IdentityVerificationScreenState
 
     if (timeLeft > 0) {
       emailCountdown = timeLeft;
-      countdownNotifier.value = emailCountdown;
+      emailCountdownNotifier.value = emailCountdown;
 
       emailTimer?.cancel();
 
@@ -121,14 +118,14 @@ class _IdentityVerificationScreenState
         int remainingTime = ((lockedUntil - currentTime) / 1000).round();
 
         if (remainingTime > 0) {
-          countdownNotifier.value = remainingTime;
+          emailCountdownNotifier.value = remainingTime;
         } else {
-          countdownNotifier.value = -1;
+          emailCountdownNotifier.value = -1;
           timer.cancel();
         }
       });
     } else {
-      countdownNotifier.value = -1;
+      emailCountdownNotifier.value = -1;
     }
   }
 
@@ -137,7 +134,7 @@ class _IdentityVerificationScreenState
       setState(() {
         emailVerified = Globals().emailVerified.value;
         if (emailVerified) {
-          countdownNotifier.value = -1;
+          emailCountdownNotifier.value = -1;
           emailTimer?.cancel();
         }
       });
@@ -390,10 +387,6 @@ class _IdentityVerificationScreenState
       return;
     }
 
-    if (countdownNotifier.value == -1) {
-      return _changeEmailDialog();
-    }
-
     sendVerificationEmail();
     resendEmailDialog(context);
   }
@@ -422,166 +415,6 @@ class _IdentityVerificationScreenState
     );
   }
 
-  Widget _fillCard(String phase, int step, String text, IconData icon) {
-    switch (phase) {
-      case 'Unverified':
-        return unVerifiedWidget(step, text, icon);
-      case 'Verified':
-        return verifiedWidget(step, text, icon);
-      case 'CurrentPhase':
-        return currentPhaseWidget(step, text, icon);
-      default:
-        return Container();
-    }
-  }
-
-  Widget unVerifiedWidget(int step, String text, IconData icon) {
-    return InkWell(
-      child: Opacity(
-        opacity: 0.5,
-        child: Padding(
-          padding: const EdgeInsets.only(bottom: 10.0),
-          child: ListTile(
-            leading: Icon(icon),
-            title: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    Expanded(
-                      child: Text(
-                        text.isEmpty ? 'Unknown' : text,
-                        overflow: TextOverflow.clip,
-                        style: TextStyle(
-                          fontWeight: FontWeight.bold,
-                          color: Theme.of(context).colorScheme.onSurface,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 5),
-                Row(
-                  children: [
-                    Icon(
-                      Icons.close,
-                      color: Theme.of(context).colorScheme.error,
-                      size: 18.0,
-                    ),
-                    const SizedBox(width: 5),
-                    Text(
-                      'Not verified',
-                      style: TextStyle(
-                        color: Theme.of(context).colorScheme.error,
-                        fontWeight: FontWeight.bold,
-                        fontSize: 12,
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget currentPhaseWidget(int step, String text, IconData icon) {
-    return InkWell(
-      onTap: () async {
-        if (step == 1 && countdownNotifier.value == -1) {
-          return _changeEmailDialog();
-        }
-
-        if (step == 2 && phoneCountdownNotifier.value == -1) {
-          if (phone.isEmpty) {
-            await addPhoneNumberDialog(context, newPhone: true, oldPhone: '');
-          } else {
-            await addPhoneNumberDialog(context,
-                newPhone: false, oldPhone: phone);
-          }
-
-          var phoneMap = await getPhone();
-          if (phoneMap.isEmpty || !phoneMap.containsKey('phone')) {
-            return;
-          }
-
-          String? phoneNumber = phoneMap['phone'];
-          if (phoneNumber == null || phoneNumber.isEmpty) {
-            return;
-          }
-
-          setState(() {
-            phone = phoneNumber;
-          });
-
-          FlutterPkid client = await getPkidClient();
-          client.setPKidDoc('phone', json.encode({'phone': phone}));
-
-          if (phone.isEmpty) {
-            return;
-          }
-        }
-      },
-      child: Column(
-        children: [
-          Padding(
-            padding: const EdgeInsets.only(bottom: 10.0),
-            child: ListTile(
-              leading: Icon(icon),
-              title: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Flexible(
-                    child: Container(
-                      constraints: _getConstraints(context, step),
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Row(
-                            children: [
-                              Expanded(
-                                child: Text(
-                                  text.isEmpty ? 'Unknown' : text,
-                                  overflow: TextOverflow.clip,
-                                ),
-                              ),
-                            ],
-                          ),
-                          if (step == 1) _buildCountdown(context, true),
-                          if (step == 2) _buildCountdown(context, false),
-                        ],
-                      ),
-                    ),
-                  ),
-                  _buildVerificationBtn(step),
-                ],
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  BoxConstraints _getConstraints(BuildContext context, int step) {
-    final hidePhoneButton = Globals().hidePhoneButton.value;
-    final screenWidth = MediaQuery.of(context).size.width;
-
-    if (hidePhoneButton == false || (step != 2 && hidePhoneButton == true)) {
-      return BoxConstraints(
-        minWidth: screenWidth * 0.5,
-        maxWidth: screenWidth * 0.5,
-      );
-    } else {
-      return BoxConstraints(
-        minWidth: screenWidth * 0.7,
-        maxWidth: screenWidth * 0.7,
-      );
-    }
-  }
-
   formatCountdownMsg(bool isEmail, int countdownValue) {
     if (isEmail) {
       return 'Verification email sent, retry in $countdownValue second${countdownValue == 1 ? '' : 's'}';
@@ -592,7 +425,7 @@ class _IdentityVerificationScreenState
 
   Widget _buildCountdown(BuildContext context, bool isEmail) {
     return ValueListenableBuilder<int>(
-      valueListenable: isEmail ? countdownNotifier : phoneCountdownNotifier,
+      valueListenable: isEmail ? emailCountdownNotifier : phoneCountdownNotifier,
       builder: (context, countdownValue, child) {
         if (countdownValue > 0) {
           return Row(
@@ -616,7 +449,7 @@ class _IdentityVerificationScreenState
 
   Widget _buildVerificationBtn(int step) {
     return ValueListenableBuilder<int>(
-      valueListenable: step == 1 ? countdownNotifier : phoneCountdownNotifier,
+      valueListenable: step == 1 ? emailCountdownNotifier : phoneCountdownNotifier,
       builder: (context, countdownValue, child) {
         return Padding(
           padding: const EdgeInsets.only(left: 20),
@@ -661,19 +494,25 @@ class _IdentityVerificationScreenState
     return '0';
   }
 
-  Widget verifiedWidget(int step, String text, IconData icon) {
+  _handleInfoWidget(step) async {
+    if (step == 1 && emailCountdownNotifier.value == -1) {
+      _changeEmailDialog();
+    } 
+    
+    if (step == 2 && phoneCountdownNotifier.value == -1){
+      await addPhoneNumberDialog(context, newPhone: false, oldPhone: phone);
+      var phoneMap = await getPhone();
+      String? phoneNumber = phoneMap['phone'];
+      setState(() {
+        phone = phoneNumber!;
+      });
+    }
+  }
+
+  Widget infoWidget(int step, String text, IconData icon, bool isVerified) {
     return InkWell(
       onTap: () async {
-        if (step == 1) {
-          _changeEmailDialog();
-        } else {
-          await addPhoneNumberDialog(context, newPhone: false, oldPhone: phone);
-          var phoneMap = await getPhone();
-          String? phoneNumber = phoneMap['phone'];
-          setState(() {
-            phone = phoneNumber!;
-          });
-        }
+        await _handleInfoWidget(step);
       },
       child: Padding(
         padding: const EdgeInsets.only(
@@ -684,30 +523,36 @@ class _IdentityVerificationScreenState
           title: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Container(
-                    constraints: BoxConstraints(
-                      minWidth: MediaQuery.of(context).size.width * 0.65,
-                      maxWidth: MediaQuery.of(context).size.width * 0.65,
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Container(
+                      constraints: BoxConstraints(
+                        minWidth: MediaQuery.of(context).size.width * 0.5,
+                      ),
+                      child: Text(
+                        text.isEmpty ? 'Unknown' : text,
+                        overflow: TextOverflow.ellipsis,
+                      ),
                     ),
-                    child: Text(
-                      text.isEmpty ? 'Unknown' : text,
-                      overflow: TextOverflow.clip,
-                    ),
-                  ),
-                  const SizedBox(height: 5),
-                  Text(
-                    'Verified',
-                    style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                          color: Theme.of(context).colorScheme.primary,
-                          fontWeight: FontWeight.bold,
-                        ),
-                  ),
-                ],
+                    const SizedBox(height: 5),
+                    isVerified
+                        ? Text(
+                            'Verified',
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodySmall!
+                                .copyWith(
+                                  color: Theme.of(context).colorScheme.primary,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                          )
+                        : _buildCountdown(context, step == 1)
+                  ],
+                ),
               ),
-              const Icon(Icons.edit),
+              isVerified ? const Icon(Icons.edit) : _buildVerificationBtn(step),
             ],
           ),
         ),
@@ -723,6 +568,7 @@ class _IdentityVerificationScreenState
         padding: const EdgeInsets.symmetric(horizontal: 4.0),
         child: SingleChildScrollView(
           child: Column(
+            mainAxisSize: MainAxisSize.min,
             children: [
               const SizedBox(height: 20),
               AnimatedBuilder(
@@ -731,10 +577,6 @@ class _IdentityVerificationScreenState
                   Globals().phoneVerified,
                 ]),
                 builder: (BuildContext context, _) {
-                  final emailState =
-                      getCorrectState(1, emailVerified, phoneVerified);
-                  final phoneState =
-                      getCorrectState(2, emailVerified, phoneVerified);
                   return Column(
                     children: [
                       ListTile(
@@ -752,9 +594,9 @@ class _IdentityVerificationScreenState
                         ),
                       ),
                       customDivider(context: context),
-                      _fillCard(emailState, 1, email, Icons.email),
+                      infoWidget(1, email, Icons.email, emailVerified),
                       customDivider(context: context),
-                      _fillCard(phoneState, 2, phone, Icons.phone),
+                      infoWidget(2, phone, Icons.phone, phoneVerified),
                     ],
                   );
                 },

--- a/app/lib/screens/identity_verification_screen.dart
+++ b/app/lib/screens/identity_verification_screen.dart
@@ -167,23 +167,17 @@ class IdentityVerificationScreenState
   verifyButton(bool valid, verificationPhoneNumber) async {
     try {
       if (!valid) return;
-      print('hereeeeee');
-      await loadingDialog();
-      print('after loading........');
+      loadingDialog();
       await savePhone(verificationPhoneNumber, null);
       FlutterPkid client = await getPkidClient();
       client.setPKidDoc('phone', json.encode({'phone': verificationPhoneNumber}));
       await sendPhoneVerification();
-      print('after verification');
-      // Navigator.pop(context);
+      Navigator.pop(context);
       getPhoneCountdown();
-      print('countdownnnnnnn');
     } catch (e) {
       logger.e(e);
     }
   }
-
-
 
   sendPhoneVerification() async {
     await sendVerificationSms();
@@ -192,7 +186,6 @@ class IdentityVerificationScreenState
     if (mounted) {
       setState(() {
         phoneSendDialog(context);
-        Navigator.pop(context);
         Navigator.pop(context);
       });
     }
@@ -259,7 +252,6 @@ class IdentityVerificationScreenState
   }
 
   Future loadingDialog() {
-    print('loadingggggggggggggg');
     return showDialog(
       barrierDismissible: false,
       context: context,
@@ -338,7 +330,7 @@ class IdentityVerificationScreenState
                     child: const Text('Cancel')),
                 TextButton(
                     onPressed: () async {
-                      await loadingDialog();
+                      loadingDialog();
 
                       String emailValue = controller.text.toLowerCase().trim();
                       bool isValidEmail = validateEmail(emailValue);
@@ -432,7 +424,9 @@ class IdentityVerificationScreenState
     if (phoneVerified) {
       return;
     }
+    loadingDialog();
     await sendPhoneVerification();
+    Navigator.pop(context);
     setState(() {});
   }
 
@@ -498,9 +492,7 @@ class IdentityVerificationScreenState
                       await verifyEmail();
                       getEmailCountdown(startNew: true);
                     } else {
-                      await loadingDialog();
                       await verifyPhone();
-                      Navigator.pop(context);
                       getPhoneCountdown();
                     }
                   },

--- a/app/lib/screens/identity_verification_screen.dart
+++ b/app/lib/screens/identity_verification_screen.dart
@@ -544,7 +544,7 @@ class IdentityVerificationScreenState
   Widget infoWidget(int step, String text, IconData icon, bool isVerified) {
     return InkWell(
       onTap: () async {
-        newPhone = text == 'Unknown';
+        newPhone = text == '';
         await _handleInfoWidget(step);
       },
       child: Padding(
@@ -585,7 +585,7 @@ class IdentityVerificationScreenState
                   ],
                 ),
               ),
-              isVerified || text == 'Unknown' ? const Icon(Icons.edit) : _buildVerificationBtn(step),
+              isVerified || text == 'Unknown' || text == '' ? const Icon(Icons.edit) : _buildVerificationBtn(step),
             ],
           ),
         ),

--- a/app/lib/screens/identity_verification_screen.dart
+++ b/app/lib/screens/identity_verification_screen.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:core';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:flutter_pkid/flutter_pkid.dart';
 import 'package:threebotlogin/helpers/globals.dart';
 import 'package:threebotlogin/helpers/logger.dart';
@@ -26,7 +27,7 @@ class IdentityVerificationScreen extends StatefulWidget {
 
 class IdentityVerificationScreenState
     extends State<IdentityVerificationScreen> {
-    static final GlobalKey<IdentityVerificationScreenState> globalKey =
+  static final GlobalKey<IdentityVerificationScreenState> globalKey =
       GlobalKey<IdentityVerificationScreenState>();
 
   final emailController = TextEditingController();
@@ -165,13 +166,15 @@ class IdentityVerificationScreenState
       Globals().hidePhoneButton.value = true;
     }
   }
+
   verifyButton(bool valid, verificationPhoneNumber) async {
     try {
       if (!valid) return;
       loadingDialog();
       await savePhone(verificationPhoneNumber, null);
       FlutterPkid client = await getPkidClient();
-      client.setPKidDoc('phone', json.encode({'phone': verificationPhoneNumber}));
+      client.setPKidDoc(
+          'phone', json.encode({'phone': verificationPhoneNumber}));
       await sendPhoneVerification();
       Navigator.pop(context);
       getPhoneCountdown();
@@ -295,98 +298,116 @@ class IdentityVerificationScreenState
     showDialog(
         context: context,
         builder: (BuildContext dialogContext) {
-          return StatefulBuilder(builder: (statefulContext, setCustomState) {
-            return AlertDialog(
-              title: Text('Change email',
-                  style: Theme.of(context).textTheme.headlineMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onSurface)),
-              contentPadding: const EdgeInsets.all(24),
-              content: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                      'Changing your email will require re-\u200dverification.',
-                      style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                          color: Theme.of(context).colorScheme.onSurface)),
-                  TextField(
-                    controller: controller,
-                    style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onSurface,
-                        ),
-                    decoration: InputDecoration(
-                        labelText: 'Email',
-                        errorText: validEmail ? null : errorEmail),
+          return KeyboardVisibilityBuilder(
+              builder: (context, isKeyboardVisible) {
+            return GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () {
+                FocusScope.of(context).unfocus();
+              },
+              child:
+                  StatefulBuilder(builder: (statefulContext, setCustomState) {
+                return AlertDialog(
+                  title: Text('Change email',
+                      style: Theme.of(context)
+                          .textTheme
+                          .headlineMedium!
+                          .copyWith(
+                              color: Theme.of(context).colorScheme.onSurface)),
+                  contentPadding: const EdgeInsets.all(24),
+                  content: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                          'Changing your email will require re-\u200dverification.',
+                          style: Theme.of(context)
+                              .textTheme
+                              .bodyLarge!
+                              .copyWith(
+                                  color:
+                                      Theme.of(context).colorScheme.onSurface)),
+                      TextField(
+                        controller: controller,
+                        style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                              color: Theme.of(context).colorScheme.onSurface,
+                            ),
+                        decoration: InputDecoration(
+                            labelText: 'Email',
+                            errorText: validEmail ? null : errorEmail),
+                      ),
+                      const SizedBox(
+                        height: 20,
+                      ),
+                      statusMessage
+                    ],
                   ),
-                  const SizedBox(
-                    height: 20,
-                  ),
-                  statusMessage
-                ],
-              ),
-              actions: [
-                TextButton(
-                    onPressed: () {
-                      Navigator.pop(dialogContext);
-                    },
-                    child: const Text('Cancel')),
-                TextButton(
-                    onPressed: () async {
-                      loadingDialog();
+                  actions: [
+                    TextButton(
+                        onPressed: () {
+                          Navigator.pop(dialogContext);
+                        },
+                        child: const Text('Cancel')),
+                    TextButton(
+                        onPressed: () async {
+                          loadingDialog();
 
-                      String emailValue = controller.text.toLowerCase().trim();
-                      bool isValidEmail = validateEmail(emailValue);
+                          String emailValue =
+                              controller.text.toLowerCase().trim();
+                          bool isValidEmail = validateEmail(emailValue);
 
-                      var oldEmail = await getEmail();
+                          var oldEmail = await getEmail();
 
-                      if (oldEmail['email'] == emailValue) {
-                        validEmail = false;
-                        errorEmail = 'Please enter a different email';
-                        setCustomState(() {});
-                        Navigator.pop(context);
-                        return;
-                      }
+                          if (oldEmail['email'] == emailValue) {
+                            validEmail = false;
+                            errorEmail = 'Please enter a different email';
+                            setCustomState(() {});
+                            Navigator.pop(context);
+                            return;
+                          }
 
-                      if (isValidEmail == false) {
-                        validEmail = false;
-                        errorEmail = 'Please enter a valid email';
-                        setCustomState(() {});
-                        Navigator.pop(context);
-                        return;
-                      }
+                          if (isValidEmail == false) {
+                            validEmail = false;
+                            errorEmail = 'Please enter a valid email';
+                            setCustomState(() {});
+                            Navigator.pop(context);
+                            return;
+                          }
 
-                      try {
-                        errorEmail = null;
-                        await saveEmail(emailValue, null);
-                        await updateEmailAddressOfUser();
+                          try {
+                            errorEmail = null;
+                            await saveEmail(emailValue, null);
+                            await updateEmailAddressOfUser();
 
-                        sendVerificationEmail();
+                            sendVerificationEmail();
 
-                        email = emailValue;
+                            email = emailValue;
 
-                        await setIsEmailVerified(false);
-                        await saveEmailToPKid();
+                            await setIsEmailVerified(false);
+                            await saveEmailToPKid();
 
-                        Navigator.pop(context);
-                        Navigator.pop(dialogContext);
-                        resendEmailDialog(context);
-                        getEmailCountdown(startNew: true);
+                            Navigator.pop(context);
+                            Navigator.pop(dialogContext);
+                            resendEmailDialog(context);
+                            getEmailCountdown(startNew: true);
 
-                        setState(() {});
-                      } catch (e) {
-                        logger.e(e);
-                        Navigator.pop(context);
+                            setState(() {});
+                          } catch (e) {
+                            logger.e(e);
+                            Navigator.pop(context);
 
-                        statusMessage = const Text('Something went wrong',
-                            style: TextStyle(
-                                color: Colors.red,
-                                fontWeight: FontWeight.bold));
+                            statusMessage = const Text('Something went wrong',
+                                style: TextStyle(
+                                    color: Colors.red,
+                                    fontWeight: FontWeight.bold));
 
-                        setState(() {});
-                        setCustomState(() {});
-                      }
-                    },
-                    child: const Text('Ok'))
-              ],
+                            setState(() {});
+                            setCustomState(() {});
+                          }
+                        },
+                        child: const Text('Ok'))
+                  ],
+                );
+              }),
             );
           });
         });
@@ -532,7 +553,8 @@ class IdentityVerificationScreenState
     }
 
     if (step == 2 && phoneCountdownNotifier.value == -1) {
-      await addPhoneNumberDialog(context, newPhone: newPhone, oldPhone: phone, onVerify: verifyButton);
+      await addPhoneNumberDialog(context,
+          newPhone: newPhone, oldPhone: phone, onVerify: verifyButton);
       var phoneMap = await getPhone();
       String? phoneNumber = phoneMap['phone'];
       setState(() {
@@ -585,7 +607,9 @@ class IdentityVerificationScreenState
                   ],
                 ),
               ),
-              isVerified || text == 'Unknown' || text == '' ? const Icon(Icons.edit) : _buildVerificationBtn(step),
+              isVerified || text == 'Unknown' || text == ''
+                  ? const Icon(Icons.edit)
+                  : _buildVerificationBtn(step),
             ],
           ),
         ),

--- a/app/lib/screens/identity_verification_screen.dart
+++ b/app/lib/screens/identity_verification_screen.dart
@@ -31,7 +31,6 @@ class _IdentityVerificationScreenState
   String phrase = '';
   String email = '';
   String phone = '';
-  String reference = '';
   bool emailVerified = false;
   bool phoneVerified = false;
   bool isLoading = false;
@@ -65,7 +64,6 @@ class _IdentityVerificationScreenState
   }
 
   void getPhoneCountdown() {
-    print('countdown entered');
     int currentTime = DateTime.now().millisecondsSinceEpoch;
     int lockedUntil =
         Globals().smsSentOn + (Globals().smsMinutesCoolDown * 60 * 1000);
@@ -163,7 +161,7 @@ class _IdentityVerificationScreenState
   }
 
   void getUserValues() async {
-    doubleName = (await getDoubleName())!.replaceAll('.3bot', '') ?? 'Unknown';
+    doubleName = (await getDoubleName())?.replaceAll('.3bot', '') ?? 'Unknown';
     phrase = (await getPhrase())!;
     final emailMap = await getEmail();
     if (emailMap['email'] != null) {
@@ -382,12 +380,12 @@ class _IdentityVerificationScreenState
     );
   }
 
-  void verifyEmail() {
+  Future<void> verifyEmail() async {
     if (emailVerified) {
       return;
     }
 
-    sendVerificationEmail();
+    await sendVerificationEmail();
     resendEmailDialog(context);
   }
 
@@ -395,8 +393,6 @@ class _IdentityVerificationScreenState
     if (phoneVerified) {
       return;
     }
-    getPhoneCountdown();
-
     await PhoneAlertDialogState().sendPhoneVerification();
     setState(() {});
   }
@@ -425,7 +421,8 @@ class _IdentityVerificationScreenState
 
   Widget _buildCountdown(BuildContext context, bool isEmail) {
     return ValueListenableBuilder<int>(
-      valueListenable: isEmail ? emailCountdownNotifier : phoneCountdownNotifier,
+      valueListenable:
+          isEmail ? emailCountdownNotifier : phoneCountdownNotifier,
       builder: (context, countdownValue, child) {
         if (countdownValue > 0) {
           return Row(
@@ -449,7 +446,8 @@ class _IdentityVerificationScreenState
 
   Widget _buildVerificationBtn(int step) {
     return ValueListenableBuilder<int>(
-      valueListenable: step == 1 ? emailCountdownNotifier : phoneCountdownNotifier,
+      valueListenable:
+          step == 1 ? emailCountdownNotifier : phoneCountdownNotifier,
       builder: (context, countdownValue, child) {
         return Padding(
           padding: const EdgeInsets.only(left: 20),
@@ -459,8 +457,10 @@ class _IdentityVerificationScreenState
                 : () async {
                     if (step == 1) {
                       getEmailCountdown(startNew: true);
-                      verifyEmail();
+                      await verifyEmail();
                     } else {
+                      Globals().smsSentOn =
+                          DateTime.now().millisecondsSinceEpoch;
                       getPhoneCountdown();
                       await verifyPhone();
                     }
@@ -497,9 +497,9 @@ class _IdentityVerificationScreenState
   _handleInfoWidget(step) async {
     if (step == 1 && emailCountdownNotifier.value == -1) {
       _changeEmailDialog();
-    } 
-    
-    if (step == 2 && phoneCountdownNotifier.value == -1){
+    }
+
+    if (step == 2 && phoneCountdownNotifier.value == -1) {
       await addPhoneNumberDialog(context, newPhone: false, oldPhone: phone);
       var phoneMap = await getPhone();
       String? phoneNumber = phoneMap['phone'];

--- a/app/lib/screens/identity_verification_screen.dart
+++ b/app/lib/screens/identity_verification_screen.dart
@@ -456,13 +456,13 @@ class _IdentityVerificationScreenState
                 ? null
                 : () async {
                     if (step == 1) {
-                      getEmailCountdown(startNew: true);
                       await verifyEmail();
+                      getEmailCountdown(startNew: true);
                     } else {
-                      Globals().smsSentOn =
-                          DateTime.now().millisecondsSinceEpoch;
-                      getPhoneCountdown();
+                      _loadingDialog();
                       await verifyPhone();
+                      Navigator.pop(context);
+                      getPhoneCountdown();
                     }
                   },
             child: Text(step == 1 ? 'Resend' : 'Verify'),

--- a/app/lib/widgets/phone_widget.dart
+++ b/app/lib/widgets/phone_widget.dart
@@ -181,7 +181,6 @@ class PhoneAlertDialogState extends State<PhoneAlertDialog> {
   sendPhoneVerification() async {
     await sendVerificationSms();
     Globals().hidePhoneButton.value = true;
-    Globals().smsSentOn = DateTime.now().millisecondsSinceEpoch;
     if (mounted) {
       setState(() {
         phoneSendDialog(context);

--- a/app/lib/widgets/phone_widget.dart
+++ b/app/lib/widgets/phone_widget.dart
@@ -1,19 +1,14 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
-import 'package:flutter_pkid/flutter_pkid.dart';
 import 'package:intl_mobile_field/countries.dart';
 import 'package:intl_mobile_field/intl_mobile_field.dart';
-import 'package:threebotlogin/helpers/globals.dart';
-import 'package:threebotlogin/services/open_kyc_service.dart';
 import 'package:threebotlogin/services/phone_service.dart';
-import 'package:threebotlogin/services/pkid_service.dart';
-import 'package:threebotlogin/services/shared_preference_service.dart';
 
 import 'custom_dialog.dart';
 
 Future<void> addPhoneNumberDialog(context,
-    {required bool newPhone, required String oldPhone}) async {
+    {required bool newPhone,
+    required String oldPhone,
+    required Function onVerify}) async {
   final countryCode = await getCountry();
 
   await showDialog(
@@ -22,7 +17,8 @@ Future<void> addPhoneNumberDialog(context,
     builder: (BuildContext context) => PhoneAlertDialog(
         defaultCountryCode: countryCode,
         newPhone: newPhone,
-        oldPhone: oldPhone),
+        oldPhone: oldPhone,
+        onVerify: onVerify,),
   );
 }
 
@@ -50,12 +46,14 @@ class PhoneAlertDialog extends StatefulWidget {
   final String defaultCountryCode;
   final bool newPhone;
   final String oldPhone;
+  final Function onVerify;
 
   const PhoneAlertDialog(
       {super.key,
       required this.defaultCountryCode,
       required this.newPhone,
-      required this.oldPhone});
+      required this.oldPhone,
+      required this.onVerify});
 
   @override
   State<StatefulWidget> createState() {
@@ -80,114 +78,77 @@ class PhoneAlertDialogState extends State<PhoneAlertDialog> {
   @override
   Widget build(BuildContext context) {
     return CustomDialog(
-        image: Icons.phone,
-        title: widget.newPhone ? 'Add phone number' : 'Change phone number',
-        widgetDescription: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (!widget.newPhone)
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Text(
-                  'Changing your phone will require re-\u200dverification',
-                  style: Theme.of(context)
-                      .textTheme
-                      .bodyLarge!
-                      .copyWith(color: Theme.of(context).colorScheme.onSurface),
-                ),
-              ),
-            if (!widget.newPhone)
-              const SizedBox(
-                height: 30,
-              ),
+      image: Icons.phone,
+      title: widget.newPhone ? 'Add phone number' : 'Change phone number',
+      widgetDescription: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (!widget.newPhone)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: IntlMobileField(
-                initialCountryCode: widget.defaultCountryCode,
-                decoration: const InputDecoration(
-                  labelText: 'Phone Number',
-                  border: OutlineInputBorder(
-                    borderSide: BorderSide(),
-                  ),
-                ),
+              child: Text(
+                'Changing your phone will require re-\u200dverification',
                 style: Theme.of(context)
                     .textTheme
-                    .bodyMedium!
+                    .bodyLarge!
                     .copyWith(color: Theme.of(context).colorScheme.onSurface),
-                dropdownTextStyle: Theme.of(context)
-                    .textTheme
-                    .bodyMedium!
-                    .copyWith(color: Theme.of(context).colorScheme.onSurface),
-                validator: (phone) {
-                  if (phone!.completeNumber == widget.oldPhone) {
-                    setState(() {
-                      valid = false;
-                    });
-                    return 'Please enter a different number';
-                  } else if (phone.number.length >= _country.minLength &&
-                      phone.number.length <= _country.maxLength) {
-                    setState(() {
-                      valid = true;
-                    });
-                    verificationPhoneNumber = phone.completeNumber;
-                    return null;
-                  } else {
-                    setState(() {
-                      valid = false;
-                    });
-                    return 'Invalid Mobile Number';
-                  }
-                },
-                disableLengthCheck: true,
-                onCountryChanged: (country) {
-                  if (_country != country) {
-                    valid = false;
-                  }
-                  _country = country;
-                  setState(() {});
-                },
               ),
             ),
-          ],
-        ),
-        actions: <Widget>[
-          TextButton(
-              child: const Text(
-                'Cancel',
+          if (!widget.newPhone) const SizedBox(height: 30),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: IntlMobileField(
+              initialCountryCode: widget.defaultCountryCode,
+              decoration: const InputDecoration(
+                labelText: 'Phone Number',
+                border: OutlineInputBorder(),
               ),
-              onPressed: () {
-                Navigator.pop(context);
-              }),
-          if (valid)
-            TextButton(
-                onPressed: verifyButton,
-                child: Text(widget.newPhone ? 'Add' : 'Update'))
-        ]);
-  }
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium!
+                  .copyWith(color: Theme.of(context).colorScheme.onSurface),
+              dropdownTextStyle: Theme.of(context)
+                  .textTheme
+                  .bodyMedium!
+                  .copyWith(color: Theme.of(context).colorScheme.onSurface),
+              validator: (phone) {
+                final isValid = phone != null &&
+                    phone.completeNumber != widget.oldPhone &&
+                    phone.number.length >= _country.minLength &&
+                    phone.number.length <= _country.maxLength;
 
-  void verifyButton() async {
-    if (!valid) {
-      return;
-    }
+                setState(() => valid = isValid);
+                verificationPhoneNumber = isValid ? phone.completeNumber : '';
 
-    savePhone(verificationPhoneNumber, null);
-
-    FlutterPkid client = await getPkidClient();
-    client.setPKidDoc('phone', json.encode({'phone': verificationPhoneNumber}));
-
-    await sendPhoneVerification();
-  }
-
-  sendPhoneVerification() async {
-    await sendVerificationSms();
-    Globals().hidePhoneButton.value = true;
-    Globals().smsSentOn = DateTime.now().millisecondsSinceEpoch;
-    if (mounted) {
-      setState(() {
-        phoneSendDialog(context);
-        Navigator.pop(context);
-        Navigator.pop(context);
-      });
-    }
+                return isValid
+                    ? null
+                    : (phone!.completeNumber == widget.oldPhone
+                        ? 'Please enter a different number'
+                        : 'Invalid Mobile Number');
+              },
+              disableLengthCheck: true,
+              onCountryChanged: (country) {
+                if (_country != country) valid = false;
+                _country = country;
+                setState(() {});
+              },
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          child: const Text('Cancel'),
+          onPressed: () => Navigator.pop(context),
+        ),
+        if (valid)
+          TextButton(
+            onPressed: () {
+              widget.onVerify(context, valid, verificationPhoneNumber);
+            },
+            child: Text(widget.newPhone ? 'Add' : 'Update'),
+          ),
+      ],
+    );
   }
 }

--- a/app/lib/widgets/phone_widget.dart
+++ b/app/lib/widgets/phone_widget.dart
@@ -165,33 +165,6 @@ class PhoneAlertDialogState extends State<PhoneAlertDialog> {
         ]);
   }
 
-  Future<dynamic> verifyNow() async {
-    return await showDialog(
-      context: context,
-      barrierDismissible: false,
-      builder: (BuildContext dialogContext) => CustomDialog(
-        image: Icons.info,
-        title: 'Verify phone number',
-        description: 'Do you want to verify your phone number now?',
-        actions: [
-          TextButton(
-              onPressed: () {
-                Navigator.pop(dialogContext);
-                Navigator.pop(context);
-              },
-              child: const Text('No')),
-          TextButton(
-              onPressed: () async {
-                Navigator.pop(dialogContext);
-                Navigator.pop(context);
-                await sendPhoneVerification();
-              },
-              child: const Text('Yes'))
-        ],
-      ),
-    );
-  }
-
   void verifyButton() async {
     if (!valid) {
       return;
@@ -202,7 +175,7 @@ class PhoneAlertDialogState extends State<PhoneAlertDialog> {
     FlutterPkid client = await getPkidClient();
     client.setPKidDoc('phone', json.encode({'phone': verificationPhoneNumber}));
 
-    verifyNow();
+    await sendPhoneVerification();
   }
 
   sendPhoneVerification() async {
@@ -212,6 +185,7 @@ class PhoneAlertDialogState extends State<PhoneAlertDialog> {
     if (mounted) {
       setState(() {
         phoneSendDialog(context);
+        Navigator.pop(context);
         Navigator.pop(context);
       });
     }

--- a/app/lib/widgets/phone_widget.dart
+++ b/app/lib/widgets/phone_widget.dart
@@ -88,13 +88,13 @@ class PhoneAlertDialogState extends State<PhoneAlertDialog> {
             if (!widget.newPhone)
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16),
-                  child: Text(
-                    'Changing your phone will require re-\u200dverification',
-                    style: Theme.of(context)
-                        .textTheme
-                        .bodyLarge!
-                        .copyWith(color: Theme.of(context).colorScheme.onSurface),
-                  ),
+                child: Text(
+                  'Changing your phone will require re-\u200dverification',
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodyLarge!
+                      .copyWith(color: Theme.of(context).colorScheme.onSurface),
+                ),
               ),
             if (!widget.newPhone)
               const SizedBox(
@@ -181,6 +181,7 @@ class PhoneAlertDialogState extends State<PhoneAlertDialog> {
   sendPhoneVerification() async {
     await sendVerificationSms();
     Globals().hidePhoneButton.value = true;
+    Globals().smsSentOn = DateTime.now().millisecondsSinceEpoch;
     if (mounted) {
       setState(() {
         phoneSendDialog(context);

--- a/app/lib/widgets/phone_widget.dart
+++ b/app/lib/widgets/phone_widget.dart
@@ -143,8 +143,9 @@ class PhoneAlertDialogState extends State<PhoneAlertDialog> {
         ),
         if (valid)
           TextButton(
-            onPressed: () {
-              widget.onVerify(context, valid, verificationPhoneNumber);
+            onPressed: () async{
+              await widget.onVerify(valid, verificationPhoneNumber);
+              Navigator.pop(context);
             },
             child: Text(widget.newPhone ? 'Add' : 'Update'),
           ),


### PR DESCRIPTION
### Changes

- Refactor identity
- Remove spending & unnecessary nested widgets
- Fix resend button
- Add click effect to email & phone tiles
- Show loading dialogue while verifying
- Remove the sequential verification steps (email first, then mobile). Now, email verification is separate from mobile verification.
- Combine verified & current phase widget in one
- Remove unverified widget
- Remove KYC-related code
- Remove 'Verify now' dialogue

### Related Issues

- https://github.com/threefoldtech/threefold_connect/issues/902
- https://github.com/threefoldtech/threefold_connect/issues/911
- https://github.com/threefoldtech/threefold_connect/issues/910

### Tested Scenarios

- Navigate to Identity multiple times and check user data
- Logout then login w diff account and navigate to identity
- Verify mobile
- Verify mail
- Try to verify old mobile again
- Verify mail after moile is verified
- Verify from icon
- Verify from button
- Edit mobile
- Edit mail