### PR TITLE
Fix fav icon url

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <link rel="icon" href="<%= BASE_URL %>tf_icon.svg">
+    <link rel="icon" href="./tf_icon.png">
     <title>ThreeFold Connect</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Material+Icons">


### PR DESCRIPTION
### Changes

- Fix url  

![image](https://github.com/user-attachments/assets/accee13e-fdea-4a2c-a678-9e8a5e6a126b)

### Related Issues

- https://github.com/threefoldtech/threefold_connect/issues/790

### Tested Scenarios

- Ran frontend to ensure image change
