### PR TITLE
Fix account recovery

### DIFF
--- a/app/lib/screens/recover_screen.dart
+++ b/app/lib/screens/recover_screen.dart
@@ -69,6 +69,7 @@ class _RecoverScreenState extends State<RecoverScreen> {
       if (e.toString().contains('Invalid mnemonic')) {
         throw ('Invalid mnemonic');
       }
+      rethrow;
     }
   }
 


### PR DESCRIPTION
### Changes

- Added `rethrow` to the error when public keys are not matching.
### Related Issues

- https://github.com/threefoldtech/threefold_connect/issues/945

https://github.com/user-attachments/assets/414fa544-cd49-4dbd-bd50-b3b77c110480

### Tested Scenarios
- Tested with right name and seed.
- Tested with different publickeys.
- Tested with wrong name.