### PR TITLE
update validations for naming && not activated stellar addresses

### DIFF
--- a/app/lib/widgets/add_farm.dart
+++ b/app/lib/widgets/add_farm.dart
@@ -83,6 +83,10 @@ class _NewFarmState extends State<NewFarm> {
       nameError = "Name can't be empty";
       return false;
     }
+    if (farmName.contains(' ')) {
+      nameError = "Name can't contain spaces";
+      return false;
+    }
 
     if (widget.isV4) {
       if (!isAlphanumeric(farmName)) {
@@ -105,6 +109,12 @@ class _NewFarmState extends State<NewFarm> {
     if (_selectedWallet == null) {
       setState(() {
         walletError = 'Please select a wallet';
+      });
+      return false;
+    }
+    if (_selectedWallet!.stellarBalance == '-1') {
+      setState(() {
+        walletError = 'Wallet not activated on stellar';
       });
       return false;
     }
@@ -160,7 +170,7 @@ class _NewFarmState extends State<NewFarm> {
   }
 
   Future<void> _validateAndAdd() async {
-    if(!_validateWallet()) return;
+    if (!_validateWallet()) return;
     final farmName = _nameController.text.trim();
     setState(() {
       saveLoading = true;


### PR DESCRIPTION
### Changes

- Added check for stellar to be activated before creating farm.
- Ensure farm name won't contain any spaces.
### Related Issues

- https://github.com/threefoldtech/threefold_connect/issues/1001
- https://github.com/threefoldtech/threefold_connect/issues/993
<img src="https://github.com/user-attachments/assets/d6a8265a-c491-4070-afe8-bfe28521e184" width=200>
<img src="https://github.com/user-attachments/assets/10916398-646e-4df5-8c57-b8546916ab0d" width=200>

### Tested Scenarios

- Tested creating farm with not activated stellar address.
- Tested creating farm with activated stellar address.
- Tested updating stellar address with not activated one.
- Tested creating farm with name containing spaces.
