### PR TITLE
Unify datetime format in Orders & Transactions

### DIFF
--- a/app/lib/helpers/transaction_helpers.dart
+++ b/app/lib/helpers/transaction_helpers.dart
@@ -1,6 +1,7 @@
 import 'package:decimal/decimal.dart';
 // ignore: depend_on_referenced_packages
 import 'package:intl/intl.dart';
+import 'package:threebotlogin/helpers/logger.dart';
 
 String formatAmount(String amount) {
   double parsedAmount = roundAmount(amount).toDouble();
@@ -12,3 +13,19 @@ Decimal roundAmount(String amount) {
   Decimal parsedAmount = Decimal.parse(amount).shift(2).floor().shift(-2);
   return parsedAmount;
 }
+
+/// Formats an ISO date string to a user-friendly format
+/// Uses the same format as the overview screen: yyyy-MM-dd HH:mm:ss
+String formatDateTime(String isoString) {
+  try {
+    DateTime dateTime = DateTime.parse(isoString).toLocal();
+    return '${dateTime.year}-${_twoDigits(dateTime.month)}-${_twoDigits(dateTime.day)} '
+        '${_twoDigits(dateTime.hour)}:${_twoDigits(dateTime.minute)}:${_twoDigits(dateTime.second)}';
+  } catch (e) {
+    logger.e('Error formatting date: $e');
+    return 'Unknown date';
+  }
+}
+
+/// Helper function to pad single digits with leading zero
+String _twoDigits(int n) => n.toString().padLeft(2, '0');

--- a/app/lib/screens/market/order_details.dart
+++ b/app/lib/screens/market/order_details.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:stellar_client/models/exceptions.dart';
+import 'package:threebotlogin/helpers/transaction_helpers.dart';
 import 'package:threebotlogin/models/offer.dart';
 import 'package:threebotlogin/models/wallet.dart';
 import 'package:threebotlogin/services/stellar_service.dart' as Stellar;
@@ -327,7 +328,7 @@ class _OrderDetailsWidgetState extends State<OrderDetailsWidget> {
                                     ),
                           ),
                           Text(
-                            widget.offer.lastModifiedTime,
+                            formatDateTime(widget.offer.lastModifiedTime),
                             style: Theme.of(context)
                                 .textTheme
                                 .bodyMedium!

--- a/app/lib/screens/market/overview.dart
+++ b/app/lib/screens/market/overview.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:threebotlogin/helpers/logger.dart';
+import 'package:threebotlogin/helpers/transaction_helpers.dart';
 import 'package:threebotlogin/models/market_data.dart';
 import 'package:threebotlogin/models/wallet.dart';
 import 'package:threebotlogin/providers/wallets_provider.dart';
@@ -136,7 +137,7 @@ class _OverviewWidgetState extends ConsumerState<OverviewWidget> {
         marketData = data;
         failed = false;
       });
-      lastUpdated = _formattedDateTime();
+      lastUpdated = formatDateTime(DateTime.now().toIso8601String());
       return data;
     } catch (e) {
       setState(() {
@@ -157,14 +158,6 @@ class _OverviewWidgetState extends ConsumerState<OverviewWidget> {
       _fetchMarketData();
     });
   }
-
-  String _formattedDateTime() {
-    final now = DateTime.now();
-    return '${now.year}-${_twoDigits(now.month)}-${_twoDigits(now.day)} '
-        '${_twoDigits(now.hour)}:${_twoDigits(now.minute)}:${_twoDigits(now.second)}';
-  }
-
-  String _twoDigits(int n) => n.toString().padLeft(2, '0');
 
   @override
   void dispose() {
@@ -572,7 +565,7 @@ class _OverviewWidgetState extends ConsumerState<OverviewWidget> {
 
       setState(() {
         this.marketData = marketData;
-        lastUpdated = _formattedDateTime();
+        lastUpdated = formatDateTime(DateTime.now().toIso8601String());
         failed = false;
       });
     } catch (e) {

--- a/app/lib/widgets/market/order_card.dart
+++ b/app/lib/widgets/market/order_card.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:threebotlogin/helpers/logger.dart';
+import 'package:threebotlogin/helpers/transaction_helpers.dart';
 import 'package:threebotlogin/models/offer.dart';
-import 'package:intl/intl.dart';
 import 'package:threebotlogin/models/wallet.dart' as Wallet;
 import 'package:threebotlogin/screens/market/order_details.dart';
 
@@ -21,16 +21,6 @@ class OrderCardWidget extends ConsumerStatefulWidget {
 }
 
 class _OrderCardWidgetState extends ConsumerState<OrderCardWidget> {
-  String formatDateTime(String isoString) {
-    try {
-      DateTime dateTime = DateTime.parse(isoString).toLocal();
-      return DateFormat('yyyy-MM-dd HH:mm:ss').format(dateTime);
-    } catch (e) {
-      logger.e('Error formatting date: $e');
-      return 'Unknown date';
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     try {

--- a/app/lib/widgets/wallets/transaction.dart
+++ b/app/lib/widgets/wallets/transaction.dart
@@ -67,7 +67,7 @@ class TransactionWidget extends StatelessWidget {
                                       : Theme.of(context).colorScheme.error,
                                 )),
                       ),
-                      Text(transaction.date,
+                      Text(formatDateTime(transaction.date),
                           overflow: TextOverflow.ellipsis,
                           style: Theme.of(context)
                               .textTheme

--- a/app/lib/widgets/wallets/transaction_details.dart
+++ b/app/lib/widgets/wallets/transaction_details.dart
@@ -80,7 +80,7 @@ class TransactionDetails extends StatelessWidget {
           const Divider(),
           buildDetailRow('Asset', transaction.asset),
           const Divider(),
-          buildDetailRow('Date', transaction.date),
+          buildDetailRow('Date', formatDateTime(transaction.date)),
           const Divider(),
           buildDetailRow('Memo', transaction.memo),
           const Divider(),


### PR DESCRIPTION
### Changes

- Unify formatting datetime in orders & transactions & remove duplicate code

<img src=https://github.com/user-attachments/assets/8eb1cfde-d241-4f5b-86bc-7bfe167ef8d6 width=250>
<img src=https://github.com/user-attachments/assets/ee2ba2de-fe97-4db7-99d7-23795dac6723 width=250>

<img src=https://github.com/user-attachments/assets/d8e08859-1883-40b1-a7de-027038a0a17d width=250>
<img src=https://github.com/user-attachments/assets/cd5e48b5-7017-479b-88f5-bb56e28ca1dc width=250>


### Related Issues

- https://github.com/threefoldtech/threefold_connect/issues/1093

### Tested Scenarios

A list of scenarios tried to match the deliverables
