### PR TITLE
Replace SharedPreferences with flutter_secure_storage for storing secrets

### DIFF
--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -31,6 +31,8 @@ PODS:
     - Flutter
   - flutter_pkid (0.0.1):
     - Flutter
+  - flutter_secure_storage (6.0.0):
+    - Flutter
   - idenfy_sdk_flutter (2.6.5):
     - Flutter
     - iDenfySDK/iDenfyLiveness (= 8.6.8)
@@ -90,6 +92,7 @@ DEPENDENCIES:
   - flutter_inappwebview_ios (from `.symlinks/plugins/flutter_inappwebview_ios/ios`)
   - flutter_keyboard_visibility (from `.symlinks/plugins/flutter_keyboard_visibility/ios`)
   - flutter_pkid (from `.symlinks/plugins/flutter_pkid/ios`)
+  - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - idenfy_sdk_flutter (from `.symlinks/plugins/idenfy_sdk_flutter/ios`)
   - just_audio (from `.symlinks/plugins/just_audio/darwin`)
   - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
@@ -138,6 +141,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_keyboard_visibility/ios"
   flutter_pkid:
     :path: ".symlinks/plugins/flutter_pkid/ios"
+  flutter_secure_storage:
+    :path: ".symlinks/plugins/flutter_secure_storage/ios"
   idenfy_sdk_flutter:
     :path: ".symlinks/plugins/idenfy_sdk_flutter/ios"
   just_audio:
@@ -182,6 +187,7 @@ SPEC CHECKSUMS:
   flutter_inappwebview_ios: b89ba3482b96fb25e00c967aae065701b66e9b99
   flutter_keyboard_visibility: 4625131e43015dbbe759d9b20daaf77e0e3f6619
   flutter_pkid: 816b9b6b9e0db3bd65fb88a23a6e70e6a3e9473e
+  flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
   idenfy_sdk_flutter: 446c31efa9ec9be62654bb03304506e76bf3327a
   iDenfySDK: 8424b9e1b0887802d3b5ff8ec85f7f652e02d3df
   IosAwnCore: 653786a911089012092ce831f2945cd339855a89

--- a/app/lib/services/secure_storage_service.dart
+++ b/app/lib/services/secure_storage_service.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class SecureStorageService {
+  static const _storage = FlutterSecureStorage(
+    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+    iOptions: IOSOptions(
+      accessibility: KeychainAccessibility.first_unlock_this_device,
+    ),
+  );
+
+  static Future<void> savePrivateKey(Uint8List privateKey) async {
+    await _storage.write(
+      key: 'privatekey',
+      value: base64.encode(privateKey),
+    );
+  }
+
+  static Future<Uint8List?> getPrivateKey() async {
+    final encoded = await _storage.read(key: 'privatekey');
+    return encoded != null ? base64.decode(encoded) : null;
+  }
+
+  static Future<void> savePin(String pin) async {
+    await _storage.write(key: 'pin', value: pin);
+  }
+
+  static Future<String?> getPin() async {
+    return await _storage.read(key: 'pin');
+  }
+
+  static Future<void> savePhrase(String phrase) async {
+    await _storage.write(key: 'phrase', value: phrase);
+  }
+
+  static Future<String?> getPhrase() async {
+    return await _storage.read(key: 'phrase');
+  }
+
+  static Future<void> clearAll() async {
+    await _storage.deleteAll();
+  }
+}

--- a/app/lib/services/shared_preference_service.dart
+++ b/app/lib/services/shared_preference_service.dart
@@ -5,11 +5,13 @@ import 'package:convert/convert.dart';
 import 'package:flutter_pkid/flutter_pkid.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:threebotlogin/helpers/globals.dart';
+import 'package:threebotlogin/helpers/logger.dart';
 import 'package:threebotlogin/models/wallet_data.dart';
 import 'package:threebotlogin/services/3bot_service.dart';
 import 'package:threebotlogin/services/crypto_service.dart';
 import 'package:threebotlogin/services/open_kyc_service.dart';
 import 'package:threebotlogin/services/pkid_service.dart';
+import 'package:threebotlogin/services/secure_storage_service.dart';
 import 'package:pinenacl/api.dart';
 import 'package:pinenacl/tweetnacl.dart' show TweetNaClExt;
 
@@ -69,37 +71,42 @@ Future<void> setPublicKeyFixed() async {
 }
 
 Future<Uint8List> getPrivateKey() async {
-  final SharedPreferences prefs = await SharedPreferences.getInstance();
+  final secureKey = await SecureStorageService.getPrivateKey();
+  if (secureKey != null) return secureKey;
 
-  String? privateKey = prefs.getString('privatekey');
-  Uint8List decodedPrivateKey = base64.decode(privateKey!);
+  final prefs = await SharedPreferences.getInstance();
+  final privateKey = prefs.getString('privatekey');
+  if (privateKey != null) {
+    final decoded = base64.decode(privateKey);
+    await SecureStorageService.savePrivateKey(decoded);
+    await prefs.remove('privatekey');
+    return decoded;
+  }
 
-  return decodedPrivateKey;
+  throw Exception('Private key not found');
 }
 
 Future<void> savePrivateKey(Uint8List privateKey) async {
-  final SharedPreferences prefs = await SharedPreferences.getInstance();
-  prefs.remove('privatekey');
-
-  String encodedPrivateKey = base64.encode(privateKey);
-  prefs.setString('privatekey', encodedPrivateKey);
+  await SecureStorageService.savePrivateKey(privateKey);
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.remove('privatekey');
 }
 
 Future<Map<String, String>> getEdCurveKeys() async {
-  final SharedPreferences prefs = await SharedPreferences.getInstance();
+  final prefs = await SharedPreferences.getInstance();
+  final pkEd = prefs.getString('publickey');
+  if (pkEd == null) throw Exception('Public key not found');
 
-  final String? pkEd = prefs.getString('publickey');
-  final String? skEd = prefs.getString('privatekey');
+  final skEdBytes = await getPrivateKey();
+  final skEd = base64.encode(skEdBytes);
 
   final pkCurve = Uint8List(32);
-  TweetNaClExt.crypto_sign_ed25519_pk_to_x25519_pk(
-      pkCurve, base64.decode(pkEd!));
-  final String pkCurveEncoded = base64.encode(Uint8List.fromList(pkCurve));
+  TweetNaClExt.crypto_sign_ed25519_pk_to_x25519_pk(pkCurve, base64.decode(pkEd));
+  final pkCurveEncoded = base64.encode(Uint8List.fromList(pkCurve));
 
   final skCurve = Uint8List(32);
-  TweetNaClExt.crypto_sign_ed25519_sk_to_x25519_sk(
-      skCurve, base64.decode(skEd!));
-  final String skCurveEncoded = base64.encode(Uint8List.fromList(skCurve));
+  TweetNaClExt.crypto_sign_ed25519_sk_to_x25519_sk(skCurve, base64.decode(skEd));
+  final skCurveEncoded = base64.encode(Uint8List.fromList(skCurve));
 
   return {
     'signingPublicKey': hex.encode(base64.decode(pkEd)),
@@ -110,13 +117,24 @@ Future<Map<String, String>> getEdCurveKeys() async {
 }
 
 Future<void> savePhrase(String phrase) async {
-  final SharedPreferences prefs = await SharedPreferences.getInstance();
-  prefs.setString('phrase', phrase);
+  await SecureStorageService.savePhrase(phrase);
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.remove('phrase');
 }
 
 Future<String?> getPhrase() async {
-  final SharedPreferences prefs = await SharedPreferences.getInstance();
-  return prefs.getString('phrase');
+  final securePhrase = await SecureStorageService.getPhrase();
+  if (securePhrase != null) return securePhrase;
+
+  final prefs = await SharedPreferences.getInstance();
+  final phrase = prefs.getString('phrase');
+  if (phrase != null) {
+    await SecureStorageService.savePhrase(phrase);
+    await prefs.remove('phrase');
+    return phrase;
+  }
+
+  return null;
 }
 
 Future<void> saveTwinId(int twinId) async {
@@ -246,14 +264,24 @@ Future<Uint8List> getDerivedSeed(String appId) async {
 ///
 
 Future<void> savePin(String pin) async {
-  final SharedPreferences prefs = await SharedPreferences.getInstance();
-  prefs.remove('pin');
-  prefs.setString('pin', pin);
+  await SecureStorageService.savePin(pin);
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.remove('pin');
 }
 
 Future<String?> getPin() async {
-  final SharedPreferences prefs = await SharedPreferences.getInstance();
-  return prefs.getString('pin');
+  final securePin = await SecureStorageService.getPin();
+  if (securePin != null) return securePin;
+
+  final prefs = await SharedPreferences.getInstance();
+  final pin = prefs.getString('pin');
+  if (pin != null) {
+    await SecureStorageService.savePin(pin);
+    await prefs.remove('pin');
+    return pin;
+  }
+
+  return null;
 }
 
 Future<void> saveFingerprint(fingerprint) async {
@@ -380,8 +408,9 @@ Future<List<WalletData>> getWallets() async {
 ///
 
 Future<bool> clearData() async {
-  final SharedPreferences prefs = await SharedPreferences.getInstance();
-  bool cleared = await prefs.clear();
+  final prefs = await SharedPreferences.getInstance();
+  await SecureStorageService.clearAll();
+  final cleared = await prefs.clear();
   saveInitDone();
   return cleared;
 }

--- a/app/lib/services/shared_preference_service.dart
+++ b/app/lib/services/shared_preference_service.dart
@@ -5,7 +5,6 @@ import 'package:convert/convert.dart';
 import 'package:flutter_pkid/flutter_pkid.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:threebotlogin/helpers/globals.dart';
-import 'package:threebotlogin/helpers/logger.dart';
 import 'package:threebotlogin/models/wallet_data.dart';
 import 'package:threebotlogin/services/3bot_service.dart';
 import 'package:threebotlogin/services/crypto_service.dart';
@@ -101,11 +100,13 @@ Future<Map<String, String>> getEdCurveKeys() async {
   final skEd = base64.encode(skEdBytes);
 
   final pkCurve = Uint8List(32);
-  TweetNaClExt.crypto_sign_ed25519_pk_to_x25519_pk(pkCurve, base64.decode(pkEd));
+  TweetNaClExt.crypto_sign_ed25519_pk_to_x25519_pk(
+      pkCurve, base64.decode(pkEd));
   final pkCurveEncoded = base64.encode(Uint8List.fromList(pkCurve));
 
   final skCurve = Uint8List(32);
-  TweetNaClExt.crypto_sign_ed25519_sk_to_x25519_sk(skCurve, base64.decode(skEd));
+  TweetNaClExt.crypto_sign_ed25519_sk_to_x25519_sk(
+      skCurve, base64.decode(skEd));
   final skCurveEncoded = base64.encode(Uint8List.fromList(skCurve));
 
   return {
@@ -245,7 +246,6 @@ Future<void> savePhone(String phone, String? signedPhoneIdentifier) async {
   Globals().phoneVerified.value = false;
   client.setPKidDoc('phone', json.encode({'phone': phone}));
 }
-
 
 ///
 ///

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -703,6 +703,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.2.4"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
+  flutter_secure_storage_macos:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_macos
+      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   flutter_staggered_grid_view:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -88,6 +88,7 @@ dependencies:
   background_fetch: ^1.3.8
   connectivity_plus: ^6.1.4
   awesome_notifications: ^0.10.1
+  flutter_secure_storage: ^9.2.2
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Changes:
- Add SecureStorageService using the flutter_secure_storage package
- Update SharedPreferenceService to use secure storage for sensitive data
- Implement migration logic to move existing data from SharedPreferences
  to secure storage on first access
- Add flutter_secure_storage dependency (^9.2.4)

https://github.com/threefoldtech/threefold_connect/issues/1140