### PR TITLE
Fix timer memory leaks in login and authentication screens

### DIFF
--- a/app/lib/screens/authentication_screen.dart
+++ b/app/lib/screens/authentication_screen.dart
@@ -56,6 +56,14 @@ class AuthenticationScreenState extends State<AuthenticationScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) => checkFingerprint());
   }
 
+  @override
+  void dispose() {
+    if (widget.loginData != null && widget.loginData!.isMobile == false) {
+      timer.cancel();
+    }
+    super.dispose();
+  }
+
   timeoutTimer() async {
     if (!mounted) {
       timer.cancel();

--- a/app/lib/screens/login_screen.dart
+++ b/app/lib/screens/login_screen.dart
@@ -77,6 +77,14 @@ class _LoginScreenState extends State<LoginScreen> with BlockAndRunMixin {
     });
   }
 
+  @override
+  void dispose() {
+    if (!isMobileCheck) {
+      timer.cancel();
+    }
+    super.dispose();
+  }
+
   timeoutTimer() async {
     if (!mounted) {
       timer.cancel();


### PR DESCRIPTION
### Changes

- Add dispose() method in login_screen.dart to cancel timer on cleanup
- Add dispose() method in authentication_screen.dart to cancel timer on cleanup
- Both methods check if timer was created (non-mobile flows) before cancelling

https://github.com/threefoldtech/threefold_connect/issues/1138