### PR TITLE
Fix paging controller after dispose in news & transactions

### DIFF
--- a/app/lib/apps/news/news_screen.dart
+++ b/app/lib/apps/news/news_screen.dart
@@ -64,6 +64,8 @@ class _NewsScreenState extends State<NewsScreen> {
           (startIndex + articlesPerPage).clamp(0, allEntries.length);
       final newArticles = allEntries.sublist(startIndex, endIndex);
 
+      if (!mounted) return;
+
       final isLastPage = newArticles.length < articlesPerPage;
       isLastPage
           ? _pagingController.appendLastPage(newArticles)
@@ -83,13 +85,15 @@ class _NewsScreenState extends State<NewsScreen> {
   }
 
   void _handleError(String message, Exception error) {
+    if (!mounted) return;
+
     logger.e('News feed error: $message', error: error);
 
     _isLoading = false;
 
     _pagingController.error = message;
 
-    if (mounted && context.mounted) {
+    if (context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
@@ -106,6 +110,7 @@ class _NewsScreenState extends State<NewsScreen> {
   }
 
   Future<void> _refreshNews() async {
+    if (!mounted) return;
     _pagingController.refresh();
     return Future.delayed(const Duration(milliseconds: 300));
   }

--- a/app/lib/screens/wallets/transactions.dart
+++ b/app/lib/screens/wallets/transactions.dart
@@ -31,6 +31,8 @@ class _WalletTransactionsWidgetState extends State<WalletTransactionsWidget> {
 
       final txs = await txStream.take(_pageSize).toList();
 
+      if (!mounted) return;
+
       if (txs.isEmpty) {
         _pagingController.appendLastPage([]);
         return;
@@ -46,8 +48,10 @@ class _WalletTransactionsWidgetState extends State<WalletTransactionsWidget> {
         _pagingController.appendPage(txs, adjustedPagingToken);
       }
     } catch (e) {
+      if (!mounted) return;
+
       logger.e('Failed to load transactions: $e');
-      if (mounted) {
+      if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(


### PR DESCRIPTION
### Changes

- Add mounted checks before using PagingController in async operations
to prevent "PagingController was used after being disposed" errors.

https://github.com/threefoldtech/threefold_connect/issues/1190
