### PR TITLE
Fix TabController disposal race during iOS scene-restore

### DIFF
--- a/app/lib/screens/home_screen.dart
+++ b/app/lib/screens/home_screen.dart
@@ -43,12 +43,15 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   bool timeoutExpiredInBackground = true;
   bool pinCheckOpen = false;
   late AppLinks _appLinks;
+  TabController? _ownedTabController;
 
   @override
   void dispose() {
     _sub?.cancel();
-    globals.tabController.removeListener(_handleTabSelection);
-    globals.tabController.dispose();
+    _ownedTabController?.removeListener(_handleTabSelection);
+    if (identical(globals.tabController, _ownedTabController)) {
+      _ownedTabController?.dispose();
+    }
     super.dispose();
   }
 
@@ -118,8 +121,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     super.initState();
     initUniLinks();
 
-    globals.tabController = TabController(
+    _ownedTabController = TabController(
         initialIndex: 0, length: Globals().router.routes.length, vsync: this);
+    globals.tabController = _ownedTabController!;
     globals.tabController.addListener(_handleTabSelection);
 
     Events().onEvent(GoHomeEvent().runtimeType, close);
@@ -192,7 +196,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     if (initialLink != null) {
       Events().emit(UniLinkEvent(Uri.parse(initialLink!), context));
     }
-    
+
     _appLinks = AppLinks();
     _sub = _appLinks.uriLinkStream.listen((Uri? uri) {
       if (!mounted || uri == null) {


### PR DESCRIPTION
## Summary
After completing phone/email verification on iOS, returning to the app via the SMS deep link can cause iOS to recreate the scene. Two HomeScreen instances briefly coexist: the new one assigns a fresh TabController to the global singleton in initState, then the old one's dispose runs and disposes whichever controller is currently in the global — including the new one. Tapping any home card after that hits a Null check on the disposed controller and freezes the UI.

## Related Issue
Closes #1216

## Changes
- Tracked the locally-owned TabController in HomeScreen state and only disposed it if the global still pointed at it.

## Test Results
Tested on iPhone (iOS 26.4.1) — phone verification flow completes, deep link returns to app, "Phone verified" dialog appears, home cards remain tappable.