### PR TITLE
Hide News until a working feed is available

### DIFF
--- a/app/lib/screens/registered_screen.dart
+++ b/app/lib/screens/registered_screen.dart
@@ -110,7 +110,7 @@ class _RegisteredScreenState extends State<RegisteredScreen>
                     HomeCardWidget(
                         name: 'Sign', icon: Icons.draw_sharp, pageNumber: 9),
                     HomeCardWidget(
-                        name: 'News', icon: Icons.article, pageNumber: 1),
+                        name: 'Identity', icon: Icons.person, pageNumber: 5),
                   ],
                 ),
                 const Row(
@@ -118,13 +118,7 @@ class _RegisteredScreenState extends State<RegisteredScreen>
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     HomeCardWidget(
-                        name: 'Identity', icon: Icons.person, pageNumber: 5),
-                    HomeCardWidget(
                         name: 'Settings', icon: Icons.settings, pageNumber: 7),
-                    // HomeCardWidget(
-                    //     name: 'Notifications',
-                    //     icon: Icons.notifications,
-                    //     pageNumber: 9),
                   ],
                 ),
                 const SizedBox(height: 40),

--- a/app/lib/widgets/layout_drawer.dart
+++ b/app/lib/widgets/layout_drawer.dart
@@ -168,17 +168,6 @@ class _LayoutDrawerState extends State<LayoutDrawer> {
                 minLeadingWidth: 10,
                 leading: const Padding(
                     padding: EdgeInsets.only(left: 10),
-                    child: Icon(Icons.article, size: 18)),
-                title: const Text('News'),
-                onTap: () {
-                  Navigator.pop(context);
-                  globals.tabController.animateTo(1);
-                },
-              ),
-              ListTile(
-                minLeadingWidth: 10,
-                leading: const Padding(
-                    padding: EdgeInsets.only(left: 10),
                     child: Icon(Icons.person, size: 18)),
                 title: const Text('Identity'),
                 onTap: () {


### PR DESCRIPTION
## Summary
The News feature fetches an atom feed from a URL stored in the Flagsmith \`news-url\` flag. That URL (\`https://www.threefold.io/atom.xml\`) now returns 404 and there is no working feed published anywhere on the threefold properties, so the tab always errors out. Hiding the entry points until the backend ships a feed.

## Related Issue
Closes #1219
Tracking on the news site: threefoldtech/threefold_connect_news#10

## Changes
- Removed the News card from the home grid.
- Removed the News tile from the side drawer.

## Test Results
Tested on iPhone (iOS 26.4.1) — News is no longer visible on the home grid or in the drawer; remaining cards and tiles still navigate correctly.