### PR TITLE
Update pubspec git deps after repo rename (tfgrid-sdk-dart->zos_sdk_dart)

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -18,17 +18,17 @@ dependencies:
       ref: master
   tfchain_client:
     git:
-      url: https://github.com/threefoldtech/tfgrid-sdk-dart
+      url: https://github.com/threefoldtech/zos_sdk_dart
       ref: development
       path: packages/tfchain_client
   stellar_client:
     git:
-      url: https://github.com/threefoldtech/tfgrid-sdk-dart
+      url: https://github.com/threefoldtech/zos_sdk_dart
       ref: development
       path: packages/stellar_client
   gridproxy_client:
     git:
-      url: https://github.com/threefoldtech/tfgrid-sdk-dart
+      url: https://github.com/threefoldtech/zos_sdk_dart
       ref: development
       path: packages/gridproxy_client
   registrar_client:
@@ -97,7 +97,7 @@ dependency_overrides:
   intl: ^0.19.0
   signer:
     git:
-      url: https://github.com/threefoldtech/tfgrid-sdk-dart.git
+      url: https://github.com/threefoldtech/zos_sdk_dart.git
       path: packages/signer
       ref: development
 


### PR DESCRIPTION
`app/pubspec.yaml` pulls 4 packages (`tfchain_client`, `stellar_client`, `gridproxy_client`, `signer`) via `git:` from `threefoldtech/tfgrid-sdk-dart`, which was renamed to `zos_sdk_dart`. Points the dependency URLs at the new name instead of relying on GitHub's non-permanent rename redirect.

Verified all 4 `path:` packages exist on `zos_sdk_dart@development` (200). No functional change.

Part of the repo-rename migration off GitHub redirects.